### PR TITLE
Release the macOS mic indicator when idle

### DIFF
--- a/speaktype/Services/AudioRecordingService.swift
+++ b/speaktype/Services/AudioRecordingService.swift
@@ -29,6 +29,7 @@ class AudioRecordingService: NSObject, ObservableObject {
     private var isSessionStarted = false
     private var setupTask: Task<Void, Never>?
     private var isStopping = false  // Flag to prevent appending during stop
+    private var idleSessionStopWorkItem: DispatchWorkItem?
 
     // MARK: - Chunking state
     private var chunkAssetWriter: AVAssetWriter?
@@ -184,6 +185,19 @@ class AudioRecordingService: NSObject, ObservableObject {
             // Give it a moment to fully initialize
             Thread.sleep(forTimeInterval: 0.3)
             print("🎤 Audio capture session ready")
+            self.scheduleIdleSessionStop()
+        }
+    }
+
+    /// Stop the prewarmed capture session when the recorder is no longer visible.
+    func stopSessionIfIdle() {
+        audioQueue.async {
+            self.cancelIdleSessionStop()
+            guard !self.isRecording, let session = self.captureSession, session.isRunning else {
+                return
+            }
+            print("🎤 Stopping idle audio capture session")
+            session.stopRunning()
         }
     }
 
@@ -199,6 +213,7 @@ class AudioRecordingService: NSObject, ObservableObject {
         resetMainWriterState()
         resetChunkWriterState()
         isRecording = true
+        cancelIdleSessionStop()
 
         // 2. Wrap setup in a Task so stopRecording can wait for it
         setupTask = Task { @MainActor in
@@ -353,6 +368,7 @@ class AudioRecordingService: NSObject, ObservableObject {
 
                 finishGroup.notify(queue: self.audioQueue) {
                     // Keep microphone fully idle outside active recordings.
+                    self.cancelIdleSessionStop()
                     self.captureSession?.stopRunning()
                     self.isStopping = false
                     self.shouldDiscardCurrentRecordingOutput = false
@@ -410,6 +426,27 @@ class AudioRecordingService: NSObject, ObservableObject {
         )
 
         return chunksDir
+    }
+
+    private func scheduleIdleSessionStop(delay: TimeInterval = 8) {
+        cancelIdleSessionStop()
+
+        let work = DispatchWorkItem { [weak self] in
+            guard let self = self else { return }
+            guard !self.isRecording, let session = self.captureSession, session.isRunning else {
+                return
+            }
+            print("🎤 Auto-stopping prewarmed session to save resources")
+            session.stopRunning()
+        }
+
+        idleSessionStopWorkItem = work
+        audioQueue.asyncAfter(deadline: .now() + delay, execute: work)
+    }
+
+    private func cancelIdleSessionStop() {
+        idleSessionStopWorkItem?.cancel()
+        idleSessionStopWorkItem = nil
     }
 }
 

--- a/speaktype/Services/AudioRecordingService.swift
+++ b/speaktype/Services/AudioRecordingService.swift
@@ -218,7 +218,9 @@ class AudioRecordingService: NSObject, ObservableObject {
         resetMainWriterState()
         resetChunkWriterState()
         isRecording = true
-        cancelIdleSessionStop()
+        // Hop onto audioQueue: idleSessionStopWorkItem is only ever touched there,
+        // and startRecording runs on the main thread.
+        audioQueue.async { self.cancelIdleSessionStop() }
 
         // 2. Wrap setup in a Task so stopRecording can wait for it
         setupTask = Task { @MainActor in

--- a/speaktype/Services/AudioRecordingService.swift
+++ b/speaktype/Services/AudioRecordingService.swift
@@ -33,6 +33,7 @@ class AudioRecordingService: NSObject, ObservableObject {
     private var isSessionStarted = false
     private var setupTask: Task<Void, Never>?
     private var isStopping = false  // Flag to prevent appending during stop
+    private var idleSessionStopWorkItem: DispatchWorkItem?
 
     // MARK: - Chunking state
     private var chunkAssetWriter: AVAssetWriter?
@@ -188,6 +189,19 @@ class AudioRecordingService: NSObject, ObservableObject {
             // Give it a moment to fully initialize
             Thread.sleep(forTimeInterval: 0.3)
             print("🎤 Audio capture session ready")
+            self.scheduleIdleSessionStop()
+        }
+    }
+
+    /// Stop the prewarmed capture session when the recorder is no longer visible.
+    func stopSessionIfIdle() {
+        audioQueue.async {
+            self.cancelIdleSessionStop()
+            guard !self.isRecording, let session = self.captureSession, session.isRunning else {
+                return
+            }
+            print("🎤 Stopping idle audio capture session")
+            session.stopRunning()
         }
     }
 
@@ -204,6 +218,7 @@ class AudioRecordingService: NSObject, ObservableObject {
         resetMainWriterState()
         resetChunkWriterState()
         isRecording = true
+        cancelIdleSessionStop()
 
         // 2. Wrap setup in a Task so stopRecording can wait for it
         setupTask = Task { @MainActor in
@@ -358,6 +373,7 @@ class AudioRecordingService: NSObject, ObservableObject {
 
                 finishGroup.notify(queue: self.audioQueue) {
                     // Keep microphone fully idle outside active recordings.
+                    self.cancelIdleSessionStop()
                     self.captureSession?.stopRunning()
                     self.isStopping = false
                     self.shouldDiscardCurrentRecordingOutput = false
@@ -415,6 +431,27 @@ class AudioRecordingService: NSObject, ObservableObject {
         )
 
         return chunksDir
+    }
+
+    private func scheduleIdleSessionStop(delay: TimeInterval = 8) {
+        cancelIdleSessionStop()
+
+        let work = DispatchWorkItem { [weak self] in
+            guard let self = self else { return }
+            guard !self.isRecording, let session = self.captureSession, session.isRunning else {
+                return
+            }
+            print("🎤 Auto-stopping prewarmed session to save resources")
+            session.stopRunning()
+        }
+
+        idleSessionStopWorkItem = work
+        audioQueue.asyncAfter(deadline: .now() + delay, execute: work)
+    }
+
+    private func cancelIdleSessionStop() {
+        idleSessionStopWorkItem?.cancel()
+        idleSessionStopWorkItem = nil
     }
 }
 

--- a/speaktype/Views/Overlays/MiniRecorderView.swift
+++ b/speaktype/Views/Overlays/MiniRecorderView.swift
@@ -230,6 +230,7 @@ struct MiniRecorderView: View {
             if let localEscapeMonitor = localEscapeMonitor {
                 NSEvent.removeMonitor(localEscapeMonitor)
             }
+            audioRecorder.stopSessionIfIdle()
         }
         .onChange(of: isListening) {
             // Only animate when actually recording to save CPU

--- a/speaktype/Views/Overlays/MiniRecorderView.swift
+++ b/speaktype/Views/Overlays/MiniRecorderView.swift
@@ -237,6 +237,7 @@ struct MiniRecorderView: View {
             if let localEscapeMonitor = localEscapeMonitor {
                 NSEvent.removeMonitor(localEscapeMonitor)
             }
+            audioRecorder.stopSessionIfIdle()
         }
         .onChange(of: isListening) {
             // Only animate when actually recording to save CPU


### PR DESCRIPTION
## Summary
- stop prewarmed audio capture sessions automatically after a short idle window
- cancel any pending idle shutdown once a real recording starts and force the session fully off when recording ends
- stop the capture session when the mini recorder disappears so the menu-bar mic indicator does not linger

## Validation
- xcodebuild build -scheme speaktype -destination 'platform=macOS'

## Notes
- this still needs a manual hold-mode repro check on macOS to confirm the orange mic indicator disappears after transcription completes