### PR TITLE
Add GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,109 @@
+name: Bug report
+description: Report something that is not working in SpeakType.
+title: "[Bug]: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report this. Clear details make it much easier to reproduce and fix.
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: What happened?
+      description: Describe the problem and what you were trying to do.
+      placeholder: SpeakType started recording, but...
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: List the exact actions that trigger the issue.
+      placeholder: |
+        1. Open SpeakType
+        2. Press the hotkey
+        3. ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What did you expect SpeakType to do instead?
+    validations:
+      required: true
+
+  - type: input
+    id: speaktype-version
+    attributes:
+      label: SpeakType version
+      placeholder: v1.0.29
+    validations:
+      required: true
+
+  - type: input
+    id: macos-version
+    attributes:
+      label: macOS version
+      placeholder: macOS 15.7.3 or macOS 26.2
+    validations:
+      required: true
+
+  - type: input
+    id: mac-details
+    attributes:
+      label: Mac details
+      description: Include chip and memory if you know them.
+      placeholder: M1 Max, 32 GB RAM
+    validations:
+      required: true
+
+  - type: dropdown
+    id: recording-mode
+    attributes:
+      label: Recording mode
+      options:
+        - Hold to record
+        - Toggle
+        - Not sure
+    validations:
+      required: true
+
+  - type: input
+    id: model
+    attributes:
+      label: AI model
+      placeholder: Tiny, Base, Large v3, Large v3 Turbo, etc.
+    validations:
+      required: false
+
+  - type: input
+    id: input-device
+    attributes:
+      label: Microphone or input device
+      placeholder: Built-in microphone, AirPods, external USB mic, etc.
+    validations:
+      required: false
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Screenshots or logs
+      description: Add screenshots, screen recordings, or relevant Console logs if available.
+      render: shell
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Before submitting
+      options:
+        - label: I am using the latest available SpeakType version.
+          required: true
+        - label: I searched existing issues and did not find the same report.
+          required: true

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -6,7 +6,10 @@ body:
   - type: markdown
     attributes:
       value: |
-        Thanks for taking the time to report this. Clear details make it much easier to reproduce and fix.
+        Thanks for taking the time to report this.
+
+        Before filing, open SpeakType and go to `Settings > General > Support`, then click `Copy Support Info`.
+        Paste that output below so the report already includes the version, macOS details, permissions, model, and current settings.
 
   - type: textarea
     id: summary
@@ -37,57 +40,14 @@ body:
     validations:
       required: true
 
-  - type: input
-    id: speaktype-version
+  - type: textarea
+    id: support-info
     attributes:
-      label: SpeakType version
-      placeholder: v1.0.29
+      label: Support info
+      description: Paste the output from `Settings > General > Support > Copy Support Info`.
+      render: shell
     validations:
       required: true
-
-  - type: input
-    id: macos-version
-    attributes:
-      label: macOS version
-      placeholder: macOS 15.7.3 or macOS 26.2
-    validations:
-      required: true
-
-  - type: input
-    id: mac-details
-    attributes:
-      label: Mac details
-      description: Include chip and memory if you know them.
-      placeholder: M1 Max, 32 GB RAM
-    validations:
-      required: true
-
-  - type: dropdown
-    id: recording-mode
-    attributes:
-      label: Recording mode
-      options:
-        - Hold to record
-        - Toggle
-        - Not sure
-    validations:
-      required: true
-
-  - type: input
-    id: model
-    attributes:
-      label: AI model
-      placeholder: Tiny, Base, Large v3, Large v3 Turbo, etc.
-    validations:
-      required: false
-
-  - type: input
-    id: input-device
-    attributes:
-      label: Microphone or input device
-      placeholder: Built-in microphone, AirPods, external USB mic, etc.
-    validations:
-      required: false
 
   - type: textarea
     id: logs
@@ -103,7 +63,5 @@ body:
     attributes:
       label: Before submitting
       options:
-        - label: I am using the latest available SpeakType version.
-          required: true
         - label: I searched existing issues and did not find the same report.
           required: true

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -8,8 +8,8 @@ body:
       value: |
         Thanks for taking the time to report this.
 
-        Before filing, open SpeakType and go to `Settings > General > Support`, then click `Copy Support Info`.
-        Paste that output below so the report already includes the version, macOS details, permissions, model, and current settings.
+        If your SpeakType build has `Settings > General > Support`, click `Copy Support Info` and paste that output below.
+        If not, that is fine. Please include your SpeakType version and macOS version in the report description.
 
   - type: textarea
     id: summary
@@ -44,10 +44,8 @@ body:
     id: support-info
     attributes:
       label: Support info
-      description: Paste the output from `Settings > General > Support > Copy Support Info`.
+      description: Optional. Paste the output from `Settings > General > Support > Copy Support Info`.
       render: shell
-    validations:
-      required: true
 
   - type: textarea
     id: logs

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,61 @@
+name: Feature request
+description: Suggest an improvement or new capability for SpeakType.
+title: "[Feature]: "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for helping shape SpeakType. A good feature request explains the workflow, not just the button.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem or workflow
+      description: What are you trying to do, and where does SpeakType get in the way?
+      placeholder: When I use SpeakType to...
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: Describe the behavior you would like to see.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Optional. Mention any workaround or different design you have tried.
+    validations:
+      required: false
+
+  - type: dropdown
+    id: importance
+    attributes:
+      label: How important is this to your workflow?
+      options:
+        - Nice to have
+        - Important
+        - Blocking my use of SpeakType
+    validations:
+      required: true
+
+  - type: textarea
+    id: examples
+    attributes:
+      label: Examples or references
+      description: Optional. Add screenshots, app examples, or links that clarify the request.
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Before submitting
+      options:
+        - label: I searched existing issues and did not find the same request.
+          required: true


### PR DESCRIPTION
## Summary
- Add a bug report issue form with repro steps, environment, model, recording mode, and logs
- Add a feature request issue form focused on workflow and proposed behavior
- Disable blank issues so new reports are standardized

## Verification
- git diff --check
- ruby -e 'require "yaml"; ARGV.each { |path| YAML.load_file(path); puts "ok #{path}" }' .github/ISSUE_TEMPLATE/bug_report.yml .github/ISSUE_TEMPLATE/feature_request.yml .github/ISSUE_TEMPLATE/config.yml

Created as a draft so you can review the form wording before enabling it through merge.