### PR TITLE
fix: prevent synthetic F19 from cancelling Fn hold-to-talk recording

### DIFF
--- a/speaktype/App/AppDelegate.swift
+++ b/speaktype/App/AppDelegate.swift
@@ -37,11 +37,16 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
     // MARK: - Emoji Picker Suppression
 
+    /// F19 — posted by suppressEmojiPicker(). The synthetic event inherits the live
+    /// modifier state (including the held Fn flag), so the modifier-combo cancel
+    /// guard must ignore this key code or it cancels the recording it just started.
+    private static let emojiSuppressionKeyCode: CGKeyCode = 0x50  // F19 (80)
+
     private func suppressEmojiPicker() {
         // A robust way to suppress the emoji picker is to post a harmless keydown/keyup
         // with the F19 key (a non-modifier key), which immediately breaks the Globe key's double-tap
         // or press-and-release listener without causing a spurious flagsChanged event.
-        let dummyKeyCode: CGKeyCode = 0x50  // F19 (80)
+        let dummyKeyCode = Self.emojiSuppressionKeyCode
         let eventSource = CGEventSource(stateID: .hidSystemState)
 
         if let keyDown = CGEvent(
@@ -197,6 +202,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         guard UserDefaults.standard.integer(forKey: "recordingMode") == 0 else { return }
         guard !event.modifierFlags.intersection(.deviceIndependentFlagsMask).isEmpty else { return }
         guard event.keyCode != getSelectedHotkey().keyCode else { return }
+        // Ignore the synthetic F19 posted by suppressEmojiPicker() — it carries the
+        // held Fn flag and would otherwise cancel the recording immediately.
+        guard event.keyCode != Self.emojiSuppressionKeyCode else { return }
 
         isHotkeyPressed = false
         miniRecorderController?.cancelRecording()


### PR DESCRIPTION
Fixes #76

## Problem

In hold-to-record mode with the **Fn** hotkey (the default configuration), recording is cancelled within milliseconds of starting. Toggle mode and non-Fn hotkeys are unaffected.

## Root cause

On Fn press, `suppressEmojiPicker()` posts a synthetic **F19** keyDown/keyUp built from `CGEventSource(stateID: .hidSystemState)`. The synthetic event inherits the live hardware modifier state — including the still-held Fn flag. The `keyDown` monitor `handleModifierComboEvent` (added for #43) then sees a keyDown with modifier flags whose keyCode differs from the hotkey, and calls `cancelRecording()` — cancelling the recording the app itself just started.

## Fix

- Extract the F19 key code into a shared `emojiSuppressionKeyCode` constant
- Add a guard in `handleModifierComboEvent` ignoring that key code

Intentional combo cancellation (e.g. pressing ⌘C while recording with a ⌘ hotkey) is unchanged.

## Testing

- Built Release from this branch on macOS 26.2 (Apple Silicon)
- Fn + hold: records for the full hold duration, transcribes on release ✅
- Right ⌥ + hold: still works ✅
- Modifier combo while recording still cancels as intended ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)