### PR TITLE
feat: persist selected audio input device across app restarts

### DIFF
--- a/speaktype/Services/AudioRecordingService.swift
+++ b/speaktype/Services/AudioRecordingService.swift
@@ -17,8 +17,14 @@ class AudioRecordingService: NSObject, ObservableObject {
     @Published var selectedDeviceId: String? {
         didSet {
             setupSession()
+            // Persist so the selection survives app restarts.
+            if let selectedDeviceId {
+                UserDefaults.standard.set(selectedDeviceId, forKey: Self.selectedDeviceDefaultsKey)
+            }
         }
     }
+
+    private static let selectedDeviceDefaultsKey = "selectedAudioDeviceId"
 
     private var captureSession: AVCaptureSession?
     private var audioOutput: AVCaptureAudioDataOutput?
@@ -105,8 +111,12 @@ class AudioRecordingService: NSObject, ObservableObject {
 
     override init() {
         super.init()
+        // Restore the persisted device before discovery completes; AVCaptureDevice(uniqueID:)
+        // resolves it directly, and fetchAvailableDevices() falls back if it is gone.
+        // (didSet does not fire during init, matching the previous lazy session setup.)
+        selectedDeviceId = UserDefaults.standard.string(forKey: Self.selectedDeviceDefaultsKey)
         fetchAvailableDevices()
-        if let first = availableDevices.first {
+        if selectedDeviceId == nil, let first = availableDevices.first {
             selectedDeviceId = first.uniqueID
         }
 
@@ -141,7 +151,12 @@ class AudioRecordingService: NSObject, ObservableObject {
             self.availableDevices = discoverySession.devices.filter { device in
                 !device.localizedName.localizedCaseInsensitiveContains("Microsoft Teams")
             }
-            if self.selectedDeviceId == nil, let first = self.availableDevices.first {
+            // Fall back to the first device when nothing is selected or the
+            // selected (possibly persisted) device is no longer connected.
+            let selectionIsAvailable = self.availableDevices.contains {
+                $0.uniqueID == self.selectedDeviceId
+            }
+            if !selectionIsAvailable, let first = self.availableDevices.first {
                 self.selectedDeviceId = first.uniqueID
             }
         }


### PR DESCRIPTION
Fixes #75

## Problem

The selected input device lives only in memory, so every launch resets to the first discovered device — often not the one the user wants (a virtual device like `NoSound`, or an iPhone Continuity mic as reported in #75). The user has to re-select their microphone every time.

## Changes (`AudioRecordingService`)

- **Persist on selection** — `selectedDeviceId.didSet` writes the device `uniqueID` to `UserDefaults` (`selectedAudioDeviceId`)
- **Restore on launch** — `init` reads the saved ID before discovery completes; `AVCaptureDevice(uniqueID:)` resolves it directly. `didSet` does not fire during init, preserving the existing lazy session setup.
- **Graceful fallback** — `fetchAvailableDevices()` now falls back to the first available device whenever the current selection (persisted or live) is no longer connected, not just when nothing is selected

## Testing

- Built Release on macOS 26.2 (Apple Silicon)
- Selected MacBook Pro Microphone, quit, relaunched → selection restored ✅ (previously reset to `NoSound`)
- Selection still switchable from Settings → Audio; `Active` indicator follows ✅
- Recording/transcription works on the restored device without re-selecting ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)