### PR TITLE
chore: ignore profiling artifacts and agent tooling dirs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,10 @@ dist/
 # Logs
 *.log
 
+# Code coverage / profiling artifacts
+*.profraw
+*.profdata
+
 # Temporary files
 *.swp
 *.tmp
@@ -32,6 +36,11 @@ dist/
 
 # Cursor
 .cursor/
+
+# Agent / Codex tooling
+.agents/
+.codex/
+.claude/
 
 # App-specific
 *.app


### PR DESCRIPTION
Repo hygiene only — no app code touched.

- Untrack `default.profraw` (an empty coverage/profiling output that should never have been committed)
- Add `*.profraw` / `*.profdata` to `.gitignore`
- Ignore local agent/editor tooling dirs so they aren't committed accidentally