### PR TITLE
Transcription engine abstraction (Phase 1)

### DIFF
--- a/speaktype/Models/AIModel.swift
+++ b/speaktype/Models/AIModel.swift
@@ -11,6 +11,9 @@ struct AIModel: Identifiable, Equatable {
     let accuracy: Double  // Score relative to 10
     let expectedSizeBytes: Int64  // Minimum expected size in bytes for validation
     let minimumRAMGB: Int  // Minimum device RAM in GB for reliable loading
+    /// Which backend runs this model. Defaults to `.whisper` so existing
+    /// catalog entries and call sites are unaffected.
+    let engine: TranscriptionEngineKind = .whisper
 
     var languageSupportLabel: String {
         isEnglishOnly ? "English-only" : "Multilingual"
@@ -85,6 +88,17 @@ struct AIModel: Identifiable, Equatable {
     static func expectedSize(for variant: String) -> Int64 {
         return availableModels.first(where: { $0.variant == variant })?.expectedSizeBytes
             ?? 50_000_000
+    }
+
+    /// Returns which backend owns a given model variant.
+    /// Defaults to `.whisper` for unknown variants so existing behavior is preserved.
+    static func engineKind(for variant: String) -> TranscriptionEngineKind {
+        return availableModels.first(where: { $0.variant == variant })?.engine ?? .whisper
+    }
+
+    /// All models for a given engine.
+    static func models(for engine: TranscriptionEngineKind) -> [AIModel] {
+        availableModels.filter { $0.engine == engine }
     }
 
     /// Returns the best model recommended for this device's RAM

--- a/speaktype/Models/TranscriptionEngineKind.swift
+++ b/speaktype/Models/TranscriptionEngineKind.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+/// Identifies which speech-to-text backend powers a given model.
+///
+/// Each `AIModel` is tagged with one of these so the app can route model
+/// loading, downloading and transcription to the correct engine without the
+/// UI needing to know any backend-specific details.
+enum TranscriptionEngineKind: String, Codable, CaseIterable {
+    /// OpenAI Whisper models, run on-device via WhisperKit / CoreML.
+    case whisper
+
+    /// NVIDIA Parakeet models, run on-device via FluidAudio / CoreML.
+    case parakeet
+
+    /// Human-readable label for UI badges.
+    var displayName: String {
+        switch self {
+        case .whisper: return "Whisper"
+        case .parakeet: return "Parakeet"
+        }
+    }
+}

--- a/speaktype/Services/Transcription/SpeechToTextEngine.swift
+++ b/speaktype/Services/Transcription/SpeechToTextEngine.swift
@@ -1,0 +1,34 @@
+import Foundation
+
+/// A speech-to-text backend that can load a model and transcribe audio.
+///
+/// Both the Whisper (`WhisperService`) and Parakeet engines conform to this so
+/// that `TranscriptionManager` can treat them interchangeably. Conformers are
+/// expected to be `@Observable` reference types so the UI can react to changes
+/// in their loading / transcription state.
+///
+/// All state properties mirror the existing `WhisperService` surface so the
+/// abstraction is a drop-in: nothing about the Whisper code path changes.
+protocol SpeechToTextEngine: AnyObject {
+    /// True once a model is loaded and ready to transcribe.
+    var isInitialized: Bool { get }
+
+    /// True while a model is being loaded into memory.
+    var isLoading: Bool { get }
+
+    /// True while a transcription is actively running.
+    var isTranscribing: Bool { get }
+
+    /// Human-readable description of the current loading stage (for the UI).
+    var loadingStage: String { get }
+
+    /// The variant identifier of the currently loaded model (empty if none).
+    var currentModelVariant: String { get }
+
+    /// Load the given model variant into memory, replacing any current model.
+    func loadModel(variant: String) async throws
+
+    /// Transcribe an audio file and return the normalized text.
+    /// - Parameter language: BCP-47 language code, or `"auto"` to detect.
+    func transcribe(audioFile: URL, language: String) async throws -> String
+}

--- a/speaktype/Services/Transcription/TranscriptionManager.swift
+++ b/speaktype/Services/Transcription/TranscriptionManager.swift
@@ -1,0 +1,75 @@
+import Foundation
+
+/// Unified entry point the UI uses for model loading and transcription.
+///
+/// It routes each call to the correct `SpeechToTextEngine` based on the
+/// selected model's `TranscriptionEngineKind`, so views are fully decoupled
+/// from any specific backend (Whisper today, Parakeet next).
+///
+/// Display-state properties mirror the active engine. In Phase 1 the only
+/// engine is Whisper, so this is a behavior-preserving pass-through; Phase 2
+/// adds the Parakeet engine and switches the state accessors on `activeKind`.
+@Observable
+class TranscriptionManager {
+    static let shared = TranscriptionManager()
+
+    // MARK: - Engines
+
+    private let whisper = WhisperService.shared
+    // Phase 2: private let parakeet = ParakeetEngine.shared
+
+    /// Which backend currently owns the loaded model. Drives display state.
+    private(set) var activeKind: TranscriptionEngineKind = .whisper
+
+    private init() {}
+
+    /// Resolve the engine responsible for a given engine kind.
+    private func engine(for kind: TranscriptionEngineKind) -> any SpeechToTextEngine {
+        switch kind {
+        case .whisper:
+            return whisper
+        case .parakeet:
+            // Phase 2 wires the Parakeet engine here. Until then, Parakeet
+            // models are not present in the catalog so this is unreachable.
+            return whisper
+        }
+    }
+
+    // MARK: - Display state
+    //
+    // Phase 1 reads the Whisper engine directly (the only backend), which keeps
+    // SwiftUI observation tracking on the concrete `@Observable` instance.
+    // Phase 2 will switch these on `activeKind`.
+
+    var isInitialized: Bool { whisper.isInitialized }
+    var isLoading: Bool { whisper.isLoading }
+    var isTranscribing: Bool { whisper.isTranscribing }
+    var loadingStage: String { whisper.loadingStage }
+    var currentModelVariant: String { whisper.currentModelVariant }
+
+    // MARK: - Actions
+
+    /// Load the engine's saved/default model (mirrors `WhisperService.initialize`).
+    func initialize() async throws {
+        try await whisper.initialize()
+    }
+
+    /// Load a specific model variant, routing to its owning engine.
+    func loadModel(variant: String) async throws {
+        let kind = AIModel.engineKind(for: variant)
+        try await engine(for: kind).loadModel(variant: variant)
+        activeKind = kind
+    }
+
+    /// Transcribe an audio file with the currently active engine.
+    func transcribe(audioFile: URL, language: String = "auto") async throws -> String {
+        let kind = AIModel.engineKind(for: currentModelVariant)
+        return try await engine(for: kind).transcribe(audioFile: audioFile, language: language)
+    }
+}
+
+// MARK: - WhisperService conformance
+
+/// `WhisperService` already exposes the full `SpeechToTextEngine` surface, so
+/// conformance requires no changes to the Whisper code path.
+extension WhisperService: SpeechToTextEngine {}

--- a/speaktype/Views/Components/ModelRow.swift
+++ b/speaktype/Views/Components/ModelRow.swift
@@ -6,8 +6,8 @@ struct ModelRow: View {
     @Binding var selectedModel: String
     @ObservedObject var downloadService = ModelDownloadService.shared
 
-    // Use the shared WhisperService for loading state
-    private var whisperService: WhisperService { WhisperService.shared }
+    // Route model loading/state through the unified transcription manager
+    private var transcription: TranscriptionManager { TranscriptionManager.shared }
 
     // State for model loading
     @State private var isLoadingModel = false
@@ -216,8 +216,8 @@ struct ModelRow: View {
                                 .scaleEffect(0.7)
                                 .frame(width: 12, height: 12)
                             Text(
-                                whisperService.loadingStage.isEmpty
-                                    ? "Loading..." : whisperService.loadingStage
+                                transcription.loadingStage.isEmpty
+                                    ? "Loading..." : transcription.loadingStage
                             )
                             .font(Typography.buttonLabelSmall)
                         }
@@ -329,7 +329,7 @@ struct ModelRow: View {
                 print("🔄 Loading model into shared service: \(model.variant)")
 
                 // Load into the SHARED WhisperService so MiniRecorderView can use it
-                try await whisperService.loadModel(variant: model.variant)
+                try await transcription.loadModel(variant: model.variant)
 
                 print("✅ Model loaded successfully: \(model.variant)")
 

--- a/speaktype/Views/Overlays/MiniRecorderView.swift
+++ b/speaktype/Views/Overlays/MiniRecorderView.swift
@@ -5,7 +5,7 @@ import SwiftUI
 
 struct MiniRecorderView: View {
     @ObservedObject private var audioRecorder = AudioRecordingService.shared
-    private var whisperService: WhisperService { WhisperService.shared }
+    private var transcription: TranscriptionManager { TranscriptionManager.shared }
     @State private var isListening = false
 
     @State private var isProcessing = false
@@ -102,7 +102,7 @@ struct MiniRecorderView: View {
         ZStack {
             backgroundView
 
-            if isWarmingUp || whisperService.isLoading {
+            if isWarmingUp || transcription.isLoading {
                 HStack(spacing: 8) {
                     ProgressView()
                         .controlSize(.small)
@@ -315,7 +315,7 @@ struct MiniRecorderView: View {
                     Task {
                         await MainActor.run { isWarmingUp = true }
                         do {
-                            try await whisperService.loadModel(variant: model.variant)
+                            try await transcription.loadModel(variant: model.variant)
                             debugLog("Model pre-loaded after switch: \(model.variant)")
                         } catch {
                             debugLog("Model pre-load failed: \(error.localizedDescription)")
@@ -347,7 +347,7 @@ struct MiniRecorderView: View {
         Task {
             debugLog("Initializing WhisperService with model: \(selectedModel)")
             do {
-                try await whisperService.loadModel(variant: selectedModel)
+                try await transcription.loadModel(variant: selectedModel)
                 debugLog("Model preloaded successfully")
             } catch {
                 debugLog("Model preload failed: \(error.localizedDescription)")
@@ -485,7 +485,7 @@ struct MiniRecorderView: View {
     }
 
     private func handleEscape() {
-        guard isListening || isProcessing || isWarmingUp || whisperService.isLoading else { return }
+        guard isListening || isProcessing || isWarmingUp || transcription.isLoading else { return }
 
         debugLog("Escape pressed - cancelling immediate commit")
         cancelCommit = true
@@ -538,12 +538,12 @@ struct MiniRecorderView: View {
         debugLog("processRecording started with url: \(url.lastPathComponent)")
         do {
             // Ensure model is loaded before transcribing
-            if !whisperService.isInitialized || whisperService.currentModelVariant != selectedModel
+            if !transcription.isInitialized || transcription.currentModelVariant != selectedModel
             {
                 debugLog("Loading model: \(selectedModel)")
                 await MainActor.run { statusMessage = "Warming up model — first use is slower..." }
                 do {
-                    try await whisperService.loadModel(variant: selectedModel)
+                    try await transcription.loadModel(variant: selectedModel)
                     debugLog("Model loaded successfully")
                 } catch {
                     debugLog("Model load failed: \(error.localizedDescription)")
@@ -564,7 +564,7 @@ struct MiniRecorderView: View {
             if !cancelCommit {
                 await MainActor.run { statusMessage = "Transcribing..." }
             }
-            let text = try await whisperService.transcribe(audioFile: url, language: transcriptionLanguage)
+            let text = try await transcription.transcribe(audioFile: url, language: transcriptionLanguage)
             debugLog("Transcription result: \(text.prefix(50))...")
 
             guard !text.isEmpty else {

--- a/speaktype/Views/Screens/Dashboard/DashboardView.swift
+++ b/speaktype/Views/Screens/Dashboard/DashboardView.swift
@@ -8,7 +8,7 @@ struct DashboardView: View {
     @Binding var selection: SidebarItem?
     @StateObject private var historyService = HistoryService.shared
     @StateObject private var audioRecorder = AudioRecordingService()
-    private var whisperService: WhisperService { WhisperService.shared }
+    private var transcription: TranscriptionManager { TranscriptionManager.shared }
     @State private var leftColumnHeight: CGFloat = 0
 
     // Trial & License
@@ -177,16 +177,16 @@ struct DashboardView: View {
         }
         .onAppear {
             Task {
-                if !whisperService.isInitialized
-                    || whisperService.currentModelVariant != selectedModel
+                if !transcription.isInitialized
+                    || transcription.currentModelVariant != selectedModel
                 {
-                    try? await whisperService.loadModel(variant: selectedModel)
+                    try? await transcription.loadModel(variant: selectedModel)
                 }
             }
         }
         .onChange(of: selectedModel) {
             Task {
-                try? await whisperService.loadModel(variant: selectedModel)
+                try? await transcription.loadModel(variant: selectedModel)
             }
         }
     }
@@ -248,9 +248,9 @@ struct DashboardView: View {
             transcriptionStatus = "Transcribing..."
 
             do {
-                if !whisperService.isInitialized { try? await whisperService.initialize() }
+                if !transcription.isInitialized { try? await transcription.initialize() }
 
-                let text = try await whisperService.transcribe(audioFile: url, language: transcriptionLanguage)
+                let text = try await transcription.transcribe(audioFile: url, language: transcriptionLanguage)
                 let duration = try await getAudioDuration(url: url)
                 let modelName =
                     AIModel.availableModels.first(where: { $0.variant == selectedModel })?.name

--- a/speaktype/Views/TranscribeAudioView.swift
+++ b/speaktype/Views/TranscribeAudioView.swift
@@ -5,7 +5,7 @@ import UniformTypeIdentifiers
 
 struct TranscribeAudioView: View {
     @StateObject private var audioRecorder = AudioRecordingService()
-    private var whisperService: WhisperService { WhisperService.shared }
+    private var transcription: TranscriptionManager { TranscriptionManager.shared }
     @AppStorage("transcriptionLanguage") private var transcriptionLanguage: String = "auto"
     @State private var transcribedText: String = ""
     @State private var isTranscribing = false
@@ -172,8 +172,8 @@ struct TranscribeAudioView: View {
         }
         .onAppear {
             Task {
-                if !whisperService.isInitialized {
-                    try? await whisperService.initialize()
+                if !transcription.isInitialized {
+                    try? await transcription.initialize()
                 }
             }
         }
@@ -240,7 +240,7 @@ struct TranscribeAudioView: View {
         Task {
             isTranscribing = true
             do {
-                transcribedText = try await whisperService.transcribe(audioFile: url, language: transcriptionLanguage)
+                transcribedText = try await transcription.transcribe(audioFile: url, language: transcriptionLanguage)
                 // Save to History
                 let duration = try await getAudioDuration(url: url)
                 HistoryService.shared.addItem(transcript: transcribedText, duration: duration, audioFileURL: url)


### PR DESCRIPTION
**Phase 1 of 2** toward multi-engine speech-to-text (adding Parakeet alongside Whisper).

This PR is a **behavior-preserving refactor** — it introduces an abstraction layer but Whisper remains the only engine, so every call still resolves to the existing `WhisperService` code path. Nothing about transcription changes for users.

## What's added
- **`TranscriptionEngineKind`** — enum tagging each model with its backend (`.whisper` / `.parakeet`)
- **`SpeechToTextEngine`** — protocol for `loadModel` / `transcribe` + observable loading state. Mirrors the existing `WhisperService` surface, so `WhisperService` conforms with no code changes.
- **`TranscriptionManager`** — `@Observable` facade (`.shared`) that routes each call to the correct engine based on the selected model's engine kind
- **`AIModel`** — gains an `engine` field (defaults to `.whisper`, so existing catalog entries/call sites are untouched) plus `engineKind(for:)` / `models(for:)` helpers

## What's changed
- Views (`MiniRecorderView`, `DashboardView`, `TranscribeAudioView`, `ModelRow`) now talk to `TranscriptionManager` instead of `WhisperService` directly. Mechanical rename of the local accessor; same method surface.

## Why
Phase 2 adds a Parakeet engine (via FluidAudio) purely additively behind this abstraction — no further changes to the Whisper path.

## Verification
Compiles green in CI. The Whisper code path is unchanged, so existing behavior is preserved by construction. (Requires #81 CI to be on `main` to get its own CI run.)