### PR TITLE
Add Parakeet engine via FluidAudio (Phase 2)

### DIFF
--- a/speaktype.xcodeproj/project.pbxproj
+++ b/speaktype.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		1C547F2B2F0E7DC0008120A6 /* WhisperKit in Frameworks */ = {isa = PBXBuildFile; productRef = 1C547F2A2F0E7DC0008120A6 /* WhisperKit */; };
 		1CE4CB3F2F0EF6AF00C01C62 /* KeyboardShortcuts in Frameworks */ = {isa = PBXBuildFile; productRef = 1CE4CB3E2F0EF6AF00C01C62 /* KeyboardShortcuts */; };
 		1CE4CB412F0EF86B00C01C62 /* whisperkit-cli in Frameworks */ = {isa = PBXBuildFile; productRef = 1CE4CB402F0EF86B00C01C62 /* whisperkit-cli */; };
+		FA0000000000000000000003 /* FluidAudio in Frameworks */ = {isa = PBXBuildFile; productRef = FA0000000000000000000002 /* FluidAudio */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -74,6 +75,7 @@
 				1C547F2B2F0E7DC0008120A6 /* WhisperKit in Frameworks */,
 				1CE4CB3F2F0EF6AF00C01C62 /* KeyboardShortcuts in Frameworks */,
 				1CE4CB412F0EF86B00C01C62 /* whisperkit-cli in Frameworks */,
+				FA0000000000000000000003 /* FluidAudio in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -145,6 +147,7 @@
 				1C547F2A2F0E7DC0008120A6 /* WhisperKit */,
 				1CE4CB3E2F0EF6AF00C01C62 /* KeyboardShortcuts */,
 				1CE4CB402F0EF86B00C01C62 /* whisperkit-cli */,
+				FA0000000000000000000002 /* FluidAudio */,
 			);
 			productName = speaktype;
 			productReference = 362947222F0DBC4E00BE895D /* speaktype.app */;
@@ -231,6 +234,7 @@
 			packageReferences = (
 				1C547F222F0E7D07008120A6 /* XCRemoteSwiftPackageReference "WhisperKit" */,
 				1CE4CB3D2F0EF6AF00C01C62 /* XCRemoteSwiftPackageReference "KeyboardShortcuts" */,
+				FA0000000000000000000001 /* XCRemoteSwiftPackageReference "FluidAudio" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = 362947232F0DBC4E00BE895D /* Products */;
@@ -628,6 +632,14 @@
 				minimumVersion = 2.4.0;
 			};
 		};
+		FA0000000000000000000001 /* XCRemoteSwiftPackageReference "FluidAudio" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/FluidInference/FluidAudio.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 0.15.4;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -645,6 +657,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 1C547F222F0E7D07008120A6 /* XCRemoteSwiftPackageReference "WhisperKit" */;
 			productName = "whisperkit-cli";
+		};
+		FA0000000000000000000002 /* FluidAudio */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = FA0000000000000000000001 /* XCRemoteSwiftPackageReference "FluidAudio" */;
+			productName = FluidAudio;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/speaktype.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/speaktype.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,6 +1,15 @@
 {
-  "originHash" : "9a97c8073af9b07b8c46128893fdd0b6f4eb090da4c6175aa09be32df1ea140f",
+  "originHash" : "0f11857f5bee9050d6db2d9fba0b6a89cfb4e35548e40029a5b22ec281d8572b",
   "pins" : [
+    {
+      "identity" : "fluidaudio",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/FluidInference/FluidAudio.git",
+      "state" : {
+        "revision" : "b9d43724cbdb5a980e441fd54180964e94d470f7",
+        "version" : "0.15.4"
+      }
+    },
     {
       "identity" : "keyboardshortcuts",
       "kind" : "remoteSourceControl",

--- a/speaktype/Models/AIModel.swift
+++ b/speaktype/Models/AIModel.swift
@@ -115,6 +115,19 @@ struct AIModel: Identifiable, Equatable {
             engine: .parakeet,
             englishOnlyOverride: true
         ),
+        AIModel(
+            name: "Parakeet TDT-CTC 110M",
+            variant: ParakeetCatalog.ctc110mVariant,
+            details: "English-only • Tiny & fast • Small download",
+            rating: "Great",
+            size: "~450 MB",
+            speed: 9.9,
+            accuracy: 8.5,
+            expectedSizeBytes: 200_000_000,
+            minimumRAMGB: 2,
+            engine: .parakeet,
+            englishOnlyOverride: true
+        ),
     ]
 
     /// Returns the expected minimum size for a given model variant

--- a/speaktype/Models/AIModel.swift
+++ b/speaktype/Models/AIModel.swift
@@ -12,15 +12,20 @@ struct AIModel: Identifiable, Equatable {
     let expectedSizeBytes: Int64  // Minimum expected size in bytes for validation
     let minimumRAMGB: Int  // Minimum device RAM in GB for reliable loading
     /// Which backend runs this model. Defaults to `.whisper` so existing
-    /// catalog entries and call sites are unaffected.
-    let engine: TranscriptionEngineKind = .whisper
+    /// catalog entries and call sites are unaffected. (Declared `var` so it is
+    /// part of the synthesized memberwise initializer with a default.)
+    var engine: TranscriptionEngineKind = .whisper
+    /// Explicit English-only flag for engines that don't encode it in the
+    /// variant name (e.g. Parakeet). When nil, falls back to the Whisper
+    /// `.en` suffix convention.
+    var englishOnlyOverride: Bool? = nil
 
     var languageSupportLabel: String {
         isEnglishOnly ? "English-only" : "Multilingual"
     }
 
     var isEnglishOnly: Bool {
-        variant.hasSuffix(".en")
+        englishOnlyOverride ?? variant.hasSuffix(".en")
     }
 
     // Speed/Accuracy based on OpenAI Whisper benchmarks (WER on LibriSpeech test-clean)
@@ -81,6 +86,34 @@ struct AIModel: Identifiable, Equatable {
             accuracy: 6.0,  // ~12% WER
             expectedSizeBytes: 30_000_000,
             minimumRAMGB: 2
+        ),
+        // NVIDIA Parakeet (run on-device via FluidAudio / CoreML).
+        // Transducer (TDT) models: much faster than Whisper at similar accuracy.
+        // Download size is approximate (FluidAudio fetches the int8 weight set).
+        AIModel(
+            name: "Parakeet TDT v3",
+            variant: ParakeetCatalog.v3Variant,
+            details: "Multilingual (25 languages) • Very fast • NVIDIA Parakeet",
+            rating: "Excellent",
+            size: "~2 GB",
+            speed: 9.7,
+            accuracy: 9.2,
+            expectedSizeBytes: 500_000_000,
+            minimumRAMGB: 4,
+            engine: .parakeet
+        ),
+        AIModel(
+            name: "Parakeet TDT v2",
+            variant: ParakeetCatalog.v2Variant,
+            details: "English-only • Fastest • Highest English recall",
+            rating: "Excellent",
+            size: "~2 GB",
+            speed: 9.8,
+            accuracy: 9.1,
+            expectedSizeBytes: 500_000_000,
+            minimumRAMGB: 4,
+            engine: .parakeet,
+            englishOnlyOverride: true
         ),
     ]
 

--- a/speaktype/Services/ModelDownloadService.swift
+++ b/speaktype/Services/ModelDownloadService.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Combine
+import FluidAudio
 import WhisperKit
 
 class ModelDownloadService: ObservableObject {
@@ -99,10 +100,22 @@ class ModelDownloadService: ObservableObject {
             }
         }
         
+        // Check Parakeet (FluidAudio) models, which live in their own cache dir.
+        for variant in ParakeetCatalog.variants {
+            let version = ParakeetCatalog.version(for: variant)
+            let cacheDir = AsrModels.defaultCacheDirectory(for: version)
+            if fileManager.fileExists(atPath: cacheDir.path),
+               let contents = try? fileManager.contentsOfDirectory(atPath: cacheDir.path),
+               !contents.isEmpty {
+                foundModels.insert(variant)
+                print("✅ Parakeet model \(variant) found in cache")
+            }
+        }
+
         await MainActor.run {
             // Clear all previous progress
             self.downloadProgress.removeAll()
-            
+
             // Only mark models that actually exist
             for variant in foundModels {
                 self.downloadProgress[variant] = 1.0
@@ -120,7 +133,13 @@ class ModelDownloadService: ObservableObject {
     // Asynchronous download using WhisperKit
     func downloadModel(variant: String) {
         guard isDownloading[variant] != true else { return }
-        
+
+        // Route Parakeet variants to FluidAudio.
+        if AIModel.engineKind(for: variant) == .parakeet {
+            downloadParakeetModel(variant: variant)
+            return
+        }
+
         isDownloading[variant] = true
         downloadProgress[variant] = 0.0
         downloadError[variant] = nil
@@ -230,8 +249,65 @@ class ModelDownloadService: ObservableObject {
         activeTasks[variant] = task
     }
     
+    // Download a Parakeet model via FluidAudio (CoreML weights from Hugging Face).
+    private func downloadParakeetModel(variant: String) {
+        isDownloading[variant] = true
+        downloadProgress[variant] = 0.0
+        downloadError[variant] = nil
+        print("Starting FluidAudio (Parakeet) download for: \(variant)")
+
+        let version = ParakeetCatalog.version(for: variant)
+
+        let task = Task {
+            do {
+                _ = try await AsrModels.download(
+                    version: version,
+                    progressHandler: { progress in
+                        DispatchQueue.main.async {
+                            self.downloadProgress[variant] = progress.fractionCompleted
+                        }
+                    })
+
+                if Task.isCancelled { return }
+                print("Parakeet model downloaded successfully")
+
+                DispatchQueue.main.async {
+                    self.isDownloading[variant] = false
+                    self.downloadProgress[variant] = 1.0
+                    self.activeTasks[variant] = nil
+                }
+            } catch {
+                if Task.isCancelled {
+                    print("Parakeet download cancelled for \(variant)")
+                    return
+                }
+                print("FluidAudio download error: \(error)")
+                DispatchQueue.main.async {
+                    self.isDownloading[variant] = false
+                    self.downloadProgress[variant] = 0.0
+                    self.downloadError[variant] = error.localizedDescription
+                    self.activeTasks[variant] = nil
+                }
+            }
+        }
+
+        activeTasks[variant] = task
+    }
+
     // Aggressively deletes any potential cache for this variant
     func deleteModel(variant: String) async -> String {
+        // Parakeet models are managed by FluidAudio in its own cache directory.
+        if AIModel.engineKind(for: variant) == .parakeet {
+            let version = ParakeetCatalog.version(for: variant)
+            let cacheDir = AsrModels.defaultCacheDirectory(for: version)
+            try? FileManager.default.removeItem(at: cacheDir)
+            await MainActor.run {
+                self.downloadProgress[variant] = 0.0
+                self.isDownloading[variant] = false
+            }
+            return "Deleted Parakeet model cache for \(variant)"
+        }
+
         let fileManager = FileManager.default
         let searchDirs: [FileManager.SearchPathDirectory] = [.documentDirectory, .applicationSupportDirectory, .cachesDirectory]
         

--- a/speaktype/Services/Transcription/ParakeetEngine.swift
+++ b/speaktype/Services/Transcription/ParakeetEngine.swift
@@ -9,14 +9,16 @@ import FluidAudio
 enum ParakeetCatalog {
     static let v3Variant = "parakeet-tdt-0.6b-v3"
     static let v2Variant = "parakeet-tdt-0.6b-v2"
+    static let ctc110mVariant = "parakeet-tdt-ctc-110m"
 
-    /// All Parakeet variants SpeakType ships, newest first.
-    static let variants = [v3Variant, v2Variant]
+    /// All Parakeet variants SpeakType ships.
+    static let variants = [v3Variant, v2Variant, ctc110mVariant]
 
     /// FluidAudio model version for a given catalog variant.
     static func version(for variant: String) -> AsrModelVersion {
         switch variant {
         case v2Variant: return .v2
+        case ctc110mVariant: return .tdtCtc110m
         default: return .v3
         }
     }

--- a/speaktype/Services/Transcription/ParakeetEngine.swift
+++ b/speaktype/Services/Transcription/ParakeetEngine.swift
@@ -81,9 +81,17 @@ class ParakeetEngine: SpeechToTextEngine {
         defer { isTranscribing = false }
 
         // One-shot (batch) transcription: a fresh decoder state per file.
-        // `language: nil` lets the multilingual model auto-detect.
-        var decoderState = try TdtDecoderState()
-        let result = try await manager.transcribe(audioFile, decoderState: &decoderState)
-        return result.text
+        // The decoder state must match the model's decoder-layer count — the
+        // TDT-CTC 110M model has 1 layer while the 0.6B models have 2 — or
+        // transcription fails. `language: nil` lets the model auto-detect.
+        let version = ParakeetCatalog.version(for: currentModelVariant)
+        do {
+            var decoderState = try TdtDecoderState(decoderLayers: version.decoderLayers)
+            let result = try await manager.transcribe(audioFile, decoderState: &decoderState)
+            return result.text
+        } catch {
+            print("❌ Parakeet transcription failed (\(currentModelVariant)): \(error)")
+            throw error
+        }
     }
 }

--- a/speaktype/Services/Transcription/ParakeetEngine.swift
+++ b/speaktype/Services/Transcription/ParakeetEngine.swift
@@ -1,0 +1,87 @@
+import Foundation
+import FluidAudio
+
+/// Maps SpeakType catalog variants to FluidAudio model versions.
+///
+/// Keeping this in one place lets both the engine (loading) and the model
+/// store (download / delete / existence checks) agree on which FluidAudio
+/// model a given catalog variant refers to.
+enum ParakeetCatalog {
+    static let v3Variant = "parakeet-tdt-0.6b-v3"
+    static let v2Variant = "parakeet-tdt-0.6b-v2"
+
+    /// All Parakeet variants SpeakType ships, newest first.
+    static let variants = [v3Variant, v2Variant]
+
+    /// FluidAudio model version for a given catalog variant.
+    static func version(for variant: String) -> AsrModelVersion {
+        switch variant {
+        case v2Variant: return .v2
+        default: return .v3
+        }
+    }
+}
+
+/// Speech-to-text engine backed by NVIDIA Parakeet, run on-device via
+/// FluidAudio (CoreML / Apple Neural Engine).
+///
+/// Conforms to `SpeechToTextEngine` so `TranscriptionManager` can use it
+/// interchangeably with `WhisperService`. State mirrors the Whisper engine's
+/// surface so the existing UI works unchanged.
+@Observable
+class ParakeetEngine: SpeechToTextEngine {
+    static let shared = ParakeetEngine()
+
+    var isInitialized = false
+    var isTranscribing = false
+    var isLoading = false
+    var loadingStage = ""
+    var currentModelVariant = ""
+
+    /// FluidAudio's actor that owns the loaded CoreML models.
+    private var manager: AsrManager?
+
+    private init() {}
+
+    func loadModel(variant: String) async throws {
+        // Already loaded this exact model.
+        if isInitialized, currentModelVariant == variant, manager != nil { return }
+
+        isLoading = true
+        isInitialized = false
+        loadingStage = "Preparing Parakeet model…"
+        defer { isLoading = false }
+
+        // Release any previously loaded model before loading a new one.
+        if let manager {
+            await manager.cleanup()
+        }
+        manager = nil
+
+        let version = ParakeetCatalog.version(for: variant)
+        loadingStage = "Loading Parakeet model…"
+
+        // Downloads from Hugging Face on first use, then loads from cache.
+        let models = try await AsrModels.downloadAndLoad(version: version)
+        let manager = AsrManager(config: .default)
+        try await manager.loadModels(models)
+
+        self.manager = manager
+        currentModelVariant = variant
+        isInitialized = true
+        loadingStage = ""
+    }
+
+    func transcribe(audioFile: URL, language: String) async throws -> String {
+        guard let manager else { throw ASRError.notInitialized }
+
+        isTranscribing = true
+        defer { isTranscribing = false }
+
+        // One-shot (batch) transcription: a fresh decoder state per file.
+        // `language: nil` lets the multilingual model auto-detect.
+        var decoderState = try TdtDecoderState()
+        let result = try await manager.transcribe(audioFile, decoderState: &decoderState)
+        return result.text
+    }
+}

--- a/speaktype/Services/Transcription/TranscriptionManager.swift
+++ b/speaktype/Services/Transcription/TranscriptionManager.swift
@@ -16,7 +16,7 @@ class TranscriptionManager {
     // MARK: - Engines
 
     private let whisper = WhisperService.shared
-    // Phase 2: private let parakeet = ParakeetEngine.shared
+    private let parakeet = ParakeetEngine.shared
 
     /// Which backend currently owns the loaded model. Drives display state.
     private(set) var activeKind: TranscriptionEngineKind = .whisper
@@ -29,29 +29,56 @@ class TranscriptionManager {
         case .whisper:
             return whisper
         case .parakeet:
-            // Phase 2 wires the Parakeet engine here. Until then, Parakeet
-            // models are not present in the catalog so this is unreachable.
-            return whisper
+            return parakeet
         }
     }
 
     // MARK: - Display state
     //
-    // Phase 1 reads the Whisper engine directly (the only backend), which keeps
-    // SwiftUI observation tracking on the concrete `@Observable` instance.
-    // Phase 2 will switch these on `activeKind`.
+    // These switch on `activeKind` and read the concrete `@Observable` engine
+    // directly so SwiftUI observation tracks the active backend's state.
 
-    var isInitialized: Bool { whisper.isInitialized }
-    var isLoading: Bool { whisper.isLoading }
-    var isTranscribing: Bool { whisper.isTranscribing }
-    var loadingStage: String { whisper.loadingStage }
-    var currentModelVariant: String { whisper.currentModelVariant }
+    var isInitialized: Bool {
+        switch activeKind {
+        case .whisper: return whisper.isInitialized
+        case .parakeet: return parakeet.isInitialized
+        }
+    }
+    var isLoading: Bool {
+        switch activeKind {
+        case .whisper: return whisper.isLoading
+        case .parakeet: return parakeet.isLoading
+        }
+    }
+    var isTranscribing: Bool {
+        switch activeKind {
+        case .whisper: return whisper.isTranscribing
+        case .parakeet: return parakeet.isTranscribing
+        }
+    }
+    var loadingStage: String {
+        switch activeKind {
+        case .whisper: return whisper.loadingStage
+        case .parakeet: return parakeet.loadingStage
+        }
+    }
+    var currentModelVariant: String {
+        switch activeKind {
+        case .whisper: return whisper.currentModelVariant
+        case .parakeet: return parakeet.currentModelVariant
+        }
+    }
 
     // MARK: - Actions
 
     /// Load the engine's saved/default model (mirrors `WhisperService.initialize`).
+    ///
+    /// Whisper restores its previously selected model; Parakeet is always
+    /// loaded explicitly via `loadModel`, so there is nothing to restore for it.
     func initialize() async throws {
-        try await whisper.initialize()
+        if activeKind == .whisper {
+            try await whisper.initialize()
+        }
     }
 
     /// Load a specific model variant, routing to its owning engine.


### PR DESCRIPTION
**Phase 2 of 2** — adds NVIDIA Parakeet as a selectable on-device STT engine alongside Whisper.

> Stacked on #84 (Phase 1 abstraction) — base branch is `feat/transcription-engine-abstraction`, so this diff shows only the Parakeet additions. Retarget to `main` once #84 merges.

## What's added
- **FluidAudio** (`0.15.4`) SPM dependency — runs Parakeet-TDT on CoreML/ANE, macOS 14+
- **`ParakeetEngine`** — a `SpeechToTextEngine` backed by FluidAudio's `AsrManager`. Downloads from Hugging Face on first load, transcribes a file via the TDT decoder, returns text.
- **`TranscriptionManager`** — now routes to the Parakeet engine and mirrors its loading/transcribing state when a Parakeet model is active
- **`ModelDownloadService`** — routes download / delete / on-disk detection for Parakeet variants to FluidAudio's own cache. **The Whisper path is byte-for-byte unchanged.**
- **`AIModel`** — two Parakeet catalog entries (v3 multilingual / v2 English), added at the end so the existing recommended default is unchanged, plus an explicit english-only flag for engines that don't use the `.en` suffix convention

## How users get it
The existing model picker (`AIModelsView` / `ModelRow`) now lists the Parakeet models. Download → Use → dictate, same flow as Whisper. No UI code needed changing — it all flows through the Phase 1 abstraction.

## Verification
- ✅ **Full app build succeeds locally** (FluidAudio resolved + compiled, whole app links)
- ⚠️ **Not yet runtime-tested**: actually downloading a Parakeet model (~2 GB) and confirming it transcribes correctly needs a real run on-device. The wiring compiles and matches FluidAudio's documented API, but the end-to-end transcription should get one manual smoke test.

## Notes / possible follow-ups
- Parakeet download progress is driven by FluidAudio's `progressHandler`
- Parakeet `transcribe` uses a fresh decoder state per file (batch mode); streaming could be a later enhancement
- Model `size` labels are approximate pending a real download measurement