### PR TITLE
Fix app menu showing lowercase "speaktype"

### DIFF
--- a/scripts/run-dev.sh
+++ b/scripts/run-dev.sh
@@ -22,6 +22,7 @@ xcodebuild \
   -configuration Debug \
   -derivedDataPath "$DERIVED_DATA_PATH" \
   PRODUCT_BUNDLE_IDENTIFIER="$BUNDLE_ID" \
+  APP_DISPLAY_NAME="$APP_NAME" \
   build
 
 BUILD_APP_PATH="$(find "$BUILD_PRODUCTS_PATH" -maxdepth 1 -name "*.app" -type d | head -n 1)"

--- a/speaktype.xcodeproj/project.pbxproj
+++ b/speaktype.xcodeproj/project.pbxproj
@@ -439,6 +439,7 @@
 				ENABLE_PREVIEWS = YES;
 				ENABLE_USER_SELECTED_FILES = readonly;
 				GENERATE_INFOPLIST_FILE = NO;
+				APP_DISPLAY_NAME = SpeakType;
 				INFOPLIST_FILE = speaktype/Resources/Info.plist;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -473,6 +474,7 @@
 				ENABLE_PREVIEWS = YES;
 				ENABLE_USER_SELECTED_FILES = readonly;
 				GENERATE_INFOPLIST_FILE = NO;
+				APP_DISPLAY_NAME = SpeakType;
 				INFOPLIST_FILE = speaktype/Resources/Info.plist;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				LD_RUNPATH_SEARCH_PATHS = (

--- a/speaktype/Resources/Info.plist
+++ b/speaktype/Resources/Info.plist
@@ -11,9 +11,9 @@
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>
-	<string>$(PRODUCT_NAME)</string>
+	<string>$(APP_DISPLAY_NAME)</string>
 	<key>CFBundleDisplayName</key>
-	<string>SpeakType</string>
+	<string>$(APP_DISPLAY_NAME)</string>
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>


### PR DESCRIPTION
The macOS app menu (bold name next to the Apple logo) was showing lowercase **speaktype** instead of **SpeakType**.

## Cause
The app menu reads `CFBundleName`, which `Info.plist` set to `$(PRODUCT_NAME)` — i.e. the lowercase target name `speaktype`. `CFBundleDisplayName` was correctly "SpeakType" but that key only drives Finder/Dock/About, not the menu bar.

## Fix
- New `APP_DISPLAY_NAME` build setting (default **`SpeakType`**) on the app target
- `Info.plist`: `CFBundleName` and `CFBundleDisplayName` → `$(APP_DISPLAY_NAME)`
- `run-dev.sh` overrides `APP_DISPLAY_NAME="SpeakType-Dev"` so the dev build reads **"SpeakType-Dev"** in the menu bar
- `PRODUCT_NAME` / executable untouched → release packaging still finds `speaktype.app`

## Verification
Built both variants and inspected the bundle: prod → `CFBundleName = SpeakType`, dev → `CFBundleName = SpeakType-Dev`, `CFBundleExecutable = speaktype` (unchanged).