### PR TITLE
Don't leak synthetic F19 into terminals on Fn hotkey

### DIFF
--- a/speaktype/App/AppDelegate.swift
+++ b/speaktype/App/AppDelegate.swift
@@ -37,6 +37,36 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
     // MARK: - Emoji Picker Suppression
 
+    /// Terminal emulators (and editors with integrated terminals) that render the
+    /// synthetic F19 from `suppressEmojiPicker()` as stray control characters in
+    /// the prompt. We skip emoji-picker suppression while one of these is
+    /// frontmost so the injected key never leaks into the terminal.
+    private static let terminalBundleIdentifiers: Set<String> = [
+        "com.apple.Terminal",
+        "com.googlecode.iterm2",
+        "com.mitchellh.ghostty",
+        "io.alacritty",
+        "org.alacritty",
+        "net.kovidgoyal.kitty",
+        "com.github.wez.wezterm",
+        "dev.warp.Warp-Stable",
+        "dev.warp.Warp",
+        "co.zeit.hyper",
+        "org.tabby",
+        "com.microsoft.VSCode",
+        "com.vscodium",
+        "com.todesktop.230313mzl4w4u92",  // Cursor
+    ]
+
+    /// Whether the frontmost app is a terminal where injecting a synthetic key
+    /// would surface as visible garbage characters.
+    private static func isFrontmostAppTerminal() -> Bool {
+        guard let bundleID = NSWorkspace.shared.frontmostApplication?.bundleIdentifier else {
+            return false
+        }
+        return terminalBundleIdentifiers.contains(bundleID)
+    }
+
     private func suppressEmojiPicker() {
         // A robust way to suppress the emoji picker is to post a harmless keydown/keyup
         // with the F19 key (a non-modifier key), which immediately breaks the Globe key's double-tap
@@ -168,7 +198,10 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         if isPressed && !isHotkeyPressed {
             isHotkeyPressed = true
 
-            if currentHotkey == .fn {
+            // Skip the synthetic F19 emoji-picker suppression when a terminal is
+            // frontmost — terminals echo the injected key as stray control
+            // characters in the prompt (e.g. Claude Code, iTerm, Ghostty).
+            if currentHotkey == .fn && !Self.isFrontmostAppTerminal() {
                 suppressEmojiPicker()
             }
 


### PR DESCRIPTION
## Symptom
Starting/stopping recording with the **Fn** hotkey while a terminal is focused inserts stray characters into the prompt — the boxed `?|?` seen in Claude Code / iTerm.

## Cause
`suppressEmojiPicker()` posts a synthetic **F19** keydown/keyup to break the Globe key's emoji-picker trigger. The app already suppresses the *Fn flagsChanged* event for terminals, but the **F19 itself is delivered to the focused app**, and terminals render it as a control sequence.

This is the same synthetic-F19 root cause as #76 (where it also cancels the recording).

## Fix
Skip emoji-picker suppression while a known terminal (or integrated-terminal editor) is frontmost — so the synthetic key is never injected into it. Covers Terminal, iTerm2, Ghostty, Alacritty, kitty, WezTerm, Warp, Hyper, Tabby, VS Code, VSCodium, Cursor. Non-terminal apps are unchanged.

## Trade-off (worth a look)
The conservative approach: it leaves the global keystroke path untouched (no risk to normal typing). The cost is that **in a terminal, if your Globe key is set to "Show Emoji & Symbols", the emoji picker could now appear** on Fn press (since we skip the breaker there). For most CLI/dictation use that's a non-issue, but a deeper alternative exists if preferred: tag the synthetic F19 and swallow it in the existing event tap so it's suppressed everywhere without skipping the breaker — more correct, but it expands the tap to all keystrokes, which I'd want to test on-device before shipping.

## Verification
- ✅ Builds clean
- ⚠️ Needs an on-device check: press Fn in a terminal → no stray chars; confirm the emoji picker doesn't pop up over the terminal (depends on your Globe-key setting).