### PR TITLE
Move model storage out of ~/Documents to Application Support (#38, #69)

### DIFF
--- a/speaktype/Services/ModelDownloadService.swift
+++ b/speaktype/Services/ModelDownloadService.swift
@@ -13,31 +13,16 @@ class ModelDownloadService: ObservableObject {
     private var activeTasks: [String: Task<Void, Never>] = [:] // Track running download tasks
     
     private init() {
-        // Force a custom cache directory to avoid "Multiple models found" conflicts
-        setupCustomCache()
-        
+        // Move any models left in the legacy ~/Documents/huggingface location into
+        // Application Support. No directory is created eagerly — a fresh install
+        // leaves no trace until the user actually downloads a model.
+        ModelStorage.migrateLegacyModelsIfNeeded()
+
         // Check for already-downloaded models on launch
         Task { @MainActor in
             await refreshDownloadedModels()
             // Don't auto-select - let user explicitly pick a model which will load it
         }
-    }
-    
-    private func setupCustomCache() {
-        // Use the standard Documents/huggingface location that WhisperKit expects
-        guard let documentsDir = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first else { return }
-        
-        let huggingfaceCache = documentsDir.appendingPathComponent("huggingface")
-        
-        do {
-            try FileManager.default.createDirectory(at: huggingfaceCache, withIntermediateDirectories: true)
-            print("✅ Using standard HuggingFace cache at: \(huggingfaceCache.path)")
-        } catch {
-            print("⚠️ Failed to create huggingface directory: \(error)")
-        }
-        
-        // Don't override HF_HUB_CACHE - let WhisperKit use its default behavior
-        // This ensures compatibility with the standard HuggingFace cache structure
     }
     
     // Check which models are already downloaded and update progress dictionary
@@ -49,55 +34,15 @@ class ModelDownloadService: ObservableObject {
         // NOTE: WhisperKit.fetchAvailableModels() returns ALL remote models, not local ones
         // We ONLY rely on disk-based verification to check what's actually downloaded
         
-        // Verify models actually exist on disk with proper size validation
         let fileManager = FileManager.default
-        if let documentsDir = fileManager.urls(for: .documentDirectory, in: .userDomainMask).first {
-            let whisperKitPath = documentsDir.appendingPathComponent("huggingface/models/argmaxinc/whisperkit-coreml")
-            
-            if fileManager.fileExists(atPath: whisperKitPath.path) {
-                if let contents = try? fileManager.contentsOfDirectory(at: whisperKitPath, includingPropertiesForKeys: [.isDirectoryKey]) {
-                    print("📁 Found \(contents.count) items in WhisperKit cache at \(whisperKitPath.path)")
-                    
-                    for item in contents {
-                        let modelName = item.lastPathComponent
-                        
-                        // Skip non-model directories
-                        if modelName == "config.json" || modelName == ".DS_Store" {
-                            continue
-                        }
-                        
-                        // Verify this directory has actual model files (not just empty directory)
-                        if let subContents = try? fileManager.contentsOfDirectory(at: item, includingPropertiesForKeys: [.fileSizeKey]),
-                           !subContents.isEmpty {
-                            
-                            // Check if it has the essential files for a model (must have config.json)
-                            let hasConfigJson = subContents.contains(where: { $0.lastPathComponent == "config.json" })
-                            let hasModelFiles = subContents.contains(where: { $0.lastPathComponent.hasSuffix(".mlmodelc") })
-                            
-                            if hasConfigJson && hasModelFiles {
-                                // Calculate total directory size
-                                let directorySize = Self.calculateDirectorySize(at: item)
-                                let expectedSize = AIModel.expectedSize(for: modelName)
-                                
-                                // Model is complete if it's at least 80% of expected size
-                                let minAcceptableSize = Int64(Double(expectedSize) * 0.8)
-                                
-                                if directorySize >= minAcceptableSize {
-                                    print("✅ Model \(modelName) verified: \(Self.formatBytes(directorySize)) (expected ~\(Self.formatBytes(expectedSize)))")
-                                    foundModels.insert(modelName)
-                                } else {
-                                    print("⚠️ Model \(modelName) is INCOMPLETE: \(Self.formatBytes(directorySize)) < \(Self.formatBytes(minAcceptableSize)) minimum")
-                                }
-                            } else {
-                                print("⚠️ Model \(modelName) is incomplete (missing config.json or .mlmodelc files)")
-                            }
-                        }
-                    }
-                }
-            } else {
-                print("ℹ️ WhisperKit cache directory doesn't exist yet: \(whisperKitPath.path)")
-                print("   Models will be downloaded on first use.")
-            }
+
+        // Verify models actually exist on disk with proper size validation.
+        // Scan the current Application Support location plus the legacy Documents
+        // location (in case a migration move failed or hasn't run yet).
+        var scanDirs = [ModelStorage.whisperKitModelsDir]
+        if let legacy = ModelStorage.legacyModelsDir { scanDirs.append(legacy) }
+        for dir in scanDirs {
+            scanWhisperKitModels(in: dir, into: &foundModels)
         }
         
         // Check Parakeet (FluidAudio) models, which live in their own cache dir.
@@ -130,6 +75,61 @@ class ModelDownloadService: ObservableObject {
         }
     }
     
+    // Scan a WhisperKit CoreML models directory and insert any complete variants
+    // (verified by required files + ~80% of expected size) into `foundModels`.
+    private func scanWhisperKitModels(in whisperKitPath: URL, into foundModels: inout Set<String>) {
+        let fileManager = FileManager.default
+
+        guard fileManager.fileExists(atPath: whisperKitPath.path) else {
+            print("ℹ️ WhisperKit cache directory doesn't exist yet: \(whisperKitPath.path)")
+            return
+        }
+
+        guard let contents = try? fileManager.contentsOfDirectory(at: whisperKitPath, includingPropertiesForKeys: [.isDirectoryKey]) else {
+            return
+        }
+
+        print("📁 Found \(contents.count) items in WhisperKit cache at \(whisperKitPath.path)")
+
+        for item in contents {
+            let modelName = item.lastPathComponent
+
+            // Skip non-model directories
+            if modelName == "config.json" || modelName == ".DS_Store" {
+                continue
+            }
+
+            // Verify this directory has actual model files (not just empty directory)
+            guard let subContents = try? fileManager.contentsOfDirectory(at: item, includingPropertiesForKeys: [.fileSizeKey]),
+                  !subContents.isEmpty else {
+                continue
+            }
+
+            // Check if it has the essential files for a model (must have config.json)
+            let hasConfigJson = subContents.contains(where: { $0.lastPathComponent == "config.json" })
+            let hasModelFiles = subContents.contains(where: { $0.lastPathComponent.hasSuffix(".mlmodelc") })
+
+            guard hasConfigJson && hasModelFiles else {
+                print("⚠️ Model \(modelName) is incomplete (missing config.json or .mlmodelc files)")
+                continue
+            }
+
+            // Calculate total directory size
+            let directorySize = Self.calculateDirectorySize(at: item)
+            let expectedSize = AIModel.expectedSize(for: modelName)
+
+            // Model is complete if it's at least 80% of expected size
+            let minAcceptableSize = Int64(Double(expectedSize) * 0.8)
+
+            if directorySize >= minAcceptableSize {
+                print("✅ Model \(modelName) verified: \(Self.formatBytes(directorySize)) (expected ~\(Self.formatBytes(expectedSize)))")
+                foundModels.insert(modelName)
+            } else {
+                print("⚠️ Model \(modelName) is INCOMPLETE: \(Self.formatBytes(directorySize)) < \(Self.formatBytes(minAcceptableSize)) minimum")
+            }
+        }
+    }
+
     // Asynchronous download using WhisperKit
     func downloadModel(variant: String) {
         guard isDownloading[variant] != true else { return }
@@ -143,6 +143,8 @@ class ModelDownloadService: ObservableObject {
         isDownloading[variant] = true
         downloadProgress[variant] = 0.0
         downloadError[variant] = nil
+        // Create the storage directory now, on first download — never eagerly on launch.
+        ModelStorage.ensureWhisperKitModelsDir()
         print("Starting WhisperKit download for: \(variant)")
         
         let task = Task {
@@ -163,7 +165,7 @@ class ModelDownloadService: ObservableObject {
                 // try await WhisperKit.download(variant: variant) { progress in ... }
                 
                 // likely: download(variant:progressCallback:) - 'from' usually has a default
-                let _ = try await WhisperKit.download(variant: variant, progressCallback: { progress in
+                let _ = try await WhisperKit.download(variant: variant, downloadBase: ModelStorage.whisperKitBase, progressCallback: { progress in
                     DispatchQueue.main.async {
                         self.downloadProgress[variant] = progress.fractionCompleted
                     }
@@ -208,7 +210,7 @@ class ModelDownloadService: ObservableObject {
                      
                      // Retry download once
                      do {
-                         let _ = try await WhisperKit.download(variant: variant, progressCallback: { progress in
+                         let _ = try await WhisperKit.download(variant: variant, downloadBase: ModelStorage.whisperKitBase, progressCallback: { progress in
                              DispatchQueue.main.async {
                                  self.downloadProgress[variant] = progress.fractionCompleted
                              }
@@ -360,9 +362,11 @@ class ModelDownloadService: ObservableObject {
         deletedCount += cleanupDirectory(tempHf, matchAny: [String(modelName), underscoreVariant])
         deletedCount += cleanupDirectory(tempDir, matchAny: [String(modelName), underscoreVariant])
         
-        // 4. Check Documents/huggingface/models/argmaxinc/whisperkit-coreml (standard location)
-        if let documentsDir = fileManager.urls(for: .documentDirectory, in: .userDomainMask).first {
-            let whisperKitModels = documentsDir.appendingPathComponent("huggingface/models/argmaxinc/whisperkit-coreml")
+        // 4. Check the current Application Support location and the legacy
+        //    Documents/huggingface location for whisperkit-coreml models.
+        var whisperKitModelDirs = [ModelStorage.whisperKitModelsDir]
+        if let legacy = ModelStorage.legacyModelsDir { whisperKitModelDirs.append(legacy) }
+        for whisperKitModels in whisperKitModelDirs {
             checkedPaths.append(whisperKitModels.path)
             deletedCount += cleanupDirectory(whisperKitModels, matchAny: [String(modelName), underscoreVariant])
         }

--- a/speaktype/Services/WhisperService.swift
+++ b/speaktype/Services/WhisperService.swift
@@ -174,17 +174,25 @@ class WhisperService {
         }
 
         do {
-            let documentDirectory = FileManager.default.urls(
-                for: .documentDirectory, in: .userDomainMask
-            ).first!
-            let modelFolderPath = documentDirectory.appendingPathComponent(
-                "huggingface/models/argmaxinc/whisperkit-coreml/\(variant)"
-            ).path
+            // Prefer the current Application Support location; fall back to the legacy
+            // Documents location so users who downloaded before the move keep working.
+            let newModelFolder = ModelStorage.whisperKitModelsDir
+                .appendingPathComponent(variant)
+            var modelFolder = newModelFolder
+            if !FileManager.default.fileExists(atPath: newModelFolder.path),
+                let legacyFolder = ModelStorage.legacyModelsDir?.appendingPathComponent(variant),
+                FileManager.default.fileExists(atPath: legacyFolder.path)
+            {
+                modelFolder = legacyFolder
+            }
 
-            // Use WhisperKitConfig with optimized settings
+            // Use WhisperKitConfig with optimized settings.
+            // `downloadBase` keeps any tokenizer configs WhisperKit fetches out of
+            // ~/Documents (the root cause of model-load failures on macOS 15, #38).
             let config = WhisperKitConfig(
                 model: variant,
-                modelFolder: modelFolderPath,
+                downloadBase: ModelStorage.whisperKitBase,
+                modelFolder: modelFolder.path,
                 computeOptions: ModelComputeOptions(),  // Uses GPU + Neural Engine
                 verbose: false,
                 logLevel: .error,

--- a/speaktype/Utilities/ModelStorage.swift
+++ b/speaktype/Utilities/ModelStorage.swift
@@ -1,0 +1,87 @@
+//
+//  ModelStorage.swift
+//  speaktype
+//
+//  Single source of truth for where SpeakType stores downloaded WhisperKit models.
+//
+//  Historically models were written into `~/Documents/huggingface`. That violates
+//  Apple's file-system guidelines (Documents is the user's personal space, not app
+//  storage) and, worse, relies on a Documents sandbox prompt that fails on some
+//  macOS 15 setups — leaving users unable to load any model (#38). It also littered
+//  `~/Documents` with a `huggingface/` folder on first launch, before any download.
+//
+//  Models now live under Application Support, which needs no special permission.
+//
+
+import Foundation
+
+enum ModelStorage {
+    /// WhisperKit `downloadBase`. WhisperKit stores CoreML models under
+    /// `<base>/models/argmaxinc/whisperkit-coreml/<variant>` and any tokenizer configs
+    /// it fetches under `<base>/models/openai/...`.
+    static var whisperKitBase: URL {
+        let appSupport = FileManager.default.urls(
+            for: .applicationSupportDirectory, in: .userDomainMask
+        ).first!
+        return appSupport.appendingPathComponent("SpeakType", isDirectory: true)
+    }
+
+    /// Directory that holds the WhisperKit CoreML model variants.
+    static var whisperKitModelsDir: URL {
+        whisperKitBase.appendingPathComponent(
+            "models/argmaxinc/whisperkit-coreml", isDirectory: true)
+    }
+
+    /// Pre-1.x location inside the user's Documents folder. Retained only so existing
+    /// downloads can be migrated forward (or discovered) instead of re-downloaded.
+    static var legacyBase: URL? {
+        FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first?
+            .appendingPathComponent("huggingface", isDirectory: true)
+    }
+
+    static var legacyModelsDir: URL? {
+        legacyBase?.appendingPathComponent(
+            "models/argmaxinc/whisperkit-coreml", isDirectory: true)
+    }
+
+    /// Create the models directory. Called lazily — only when a download actually
+    /// begins — so a fresh install leaves no trace until the user downloads a model.
+    @discardableResult
+    static func ensureWhisperKitModelsDir() -> URL {
+        let dir = whisperKitModelsDir
+        try? FileManager.default.createDirectory(
+            at: dir, withIntermediateDirectories: true)
+        return dir
+    }
+
+    /// Best-effort, one-time migration of any WhisperKit models sitting in the legacy
+    /// Documents location into Application Support. Non-destructive on failure: if a
+    /// move fails, the legacy copy is left in place and discovery still finds it.
+    static func migrateLegacyModelsIfNeeded() {
+        let fm = FileManager.default
+        guard let legacyDir = legacyModelsDir,
+            fm.fileExists(atPath: legacyDir.path),
+            let variants = try? fm.contentsOfDirectory(
+                at: legacyDir, includingPropertiesForKeys: [.isDirectoryKey])
+        else { return }
+
+        let newDir = whisperKitModelsDir
+        try? fm.createDirectory(at: newDir, withIntermediateDirectories: true)
+
+        for variantDir in variants {
+            let isDir = (try? variantDir.resourceValues(forKeys: [.isDirectoryKey]))?
+                .isDirectory ?? false
+            guard isDir else { continue }
+
+            let destination = newDir.appendingPathComponent(variantDir.lastPathComponent)
+            guard !fm.fileExists(atPath: destination.path) else { continue }
+
+            do {
+                try fm.moveItem(at: variantDir, to: destination)
+                print("📦 Migrated model \(variantDir.lastPathComponent) → Application Support")
+            } catch {
+                print("⚠️ Could not migrate \(variantDir.lastPathComponent): \(error)")
+            }
+        }
+    }
+}

--- a/speaktype/Views/Screens/Onboarding/OnboardingView.swift
+++ b/speaktype/Views/Screens/Onboarding/OnboardingView.swift
@@ -150,7 +150,6 @@ struct PermissionsPage: View {
     var finishAction: () -> Void
     @State private var micStatus: AVAuthorizationStatus = .notDetermined
     @State private var accessibilityStatus: Bool = false
-    @State private var documentsAccessGranted: Bool = false
     @State private var timer: Timer?
 
     var body: some View {
@@ -185,15 +184,6 @@ struct PermissionsPage: View {
                     action: requestMicPermission
                 )
 
-                // Documents Folder
-                OnboardingPermissionRow(
-                    icon: "folder.fill",
-                    title: "Documents Folder",
-                    description: "To store AI models locally on your Mac",
-                    isGranted: documentsAccessGranted,
-                    action: requestDocumentsAccess
-                )
-
                 // Accessibility
                 OnboardingPermissionRow(
                     icon: "hand.raised.fill",
@@ -209,8 +199,7 @@ struct PermissionsPage: View {
             Spacer()
 
             ContinueButton(
-                isEnabled: micStatus == .authorized && accessibilityStatus
-                    && documentsAccessGranted,
+                isEnabled: micStatus == .authorized && accessibilityStatus,
                 action: finishAction
             )
             .padding(.bottom, 48)
@@ -252,50 +241,6 @@ struct PermissionsPage: View {
             print("🔐 Accessibility status changed: \(accessibilityStatus) → \(newAccessStatus)")
         }
         accessibilityStatus = newAccessStatus
-
-        // Check documents access by verifying the huggingface folder exists or can be created
-        checkDocumentsAccess()
-    }
-
-    func checkDocumentsAccess() {
-        guard
-            let documentsDir = FileManager.default.urls(
-                for: .documentDirectory, in: .userDomainMask
-            ).first
-        else {
-            documentsAccessGranted = false
-            return
-        }
-
-        let huggingfacePath = documentsDir.appendingPathComponent("huggingface")
-        // If the folder exists or we can access it, permission was granted
-        documentsAccessGranted =
-            FileManager.default.fileExists(atPath: huggingfacePath.path)
-            || FileManager.default.isReadableFile(atPath: documentsDir.path)
-    }
-
-    func requestDocumentsAccess() {
-        guard
-            let documentsDir = FileManager.default.urls(
-                for: .documentDirectory, in: .userDomainMask
-            ).first
-        else {
-            return
-        }
-
-        let huggingfacePath = documentsDir.appendingPathComponent("huggingface")
-
-        // Creating a directory in Documents triggers the permission prompt
-        do {
-            try FileManager.default.createDirectory(
-                at: huggingfacePath, withIntermediateDirectories: true)
-            print("✅ Documents folder access granted - created huggingface directory")
-            documentsAccessGranted = true
-        } catch {
-            print("⚠️ Documents folder access error: \(error)")
-            // Permission may have been denied, or there was another error
-            documentsAccessGranted = false
-        }
     }
 
     func requestMicPermission() {


### PR DESCRIPTION
## Why
SpeakType wrote WhisperKit models into `~/Documents/huggingface` and **created that folder eagerly on every launch**, before any download — so users found a `huggingface/` folder in their Documents even after uninstalling. Worse, model + tokenizer loading depended on the Documents sandbox, which fails on some **macOS 15** setups and leaves users unable to load any model (**#38**).

## What
- **New single source of truth — `ModelStorage`** (`speaktype/Utilities/ModelStorage.swift`) pointing at `~/Library/Application Support/SpeakType`, which needs no special permission.
- **Routed downloads + tokenizer fetches there** via WhisperKit's `downloadBase` (both `WhisperKit.download` calls and `WhisperKitConfig.downloadBase`). The stray tokenizer fetch into Documents was the likely root cause of the macOS 15 load failure.
- **No eager creation** — the directory is created only when a download actually begins.
- **One-time best-effort migration** moves any existing models out of `~/Documents/huggingface` into Application Support so users don't re-download. Load / scan / delete all keep a **legacy fallback**, so nothing breaks if the move can't run.
- **Removed the obsolete "Documents Folder" onboarding permission step** (no longer a real permission).

## Relation to #69
Re-implements the intent of #69 as a focused change (that PR was 39 files of line-ending churn and conflicting). Credited the original reporter via co-author trailer.

## Testing
- ✅ `xcodebuild build` succeeds.
- ⚠️ **Needs manual verification on-device** (can't exercise the ML path in CI): fresh install → confirm no `~/Documents/huggingface` is created; download a model → confirm it lands in `~/Library/Application Support/SpeakType/models/...`; load + transcribe; and for an upgrade, confirm existing Documents models migrate and still load. Worth a specific check on **macOS 15** for #38.

Closes #69