### PR TITLE
Give Debug builds a separate app identity (SpeakType-Dev)

### DIFF
--- a/speaktype.xcodeproj/project.pbxproj
+++ b/speaktype.xcodeproj/project.pbxproj
@@ -443,7 +443,7 @@
 				ENABLE_PREVIEWS = YES;
 				ENABLE_USER_SELECTED_FILES = readonly;
 				GENERATE_INFOPLIST_FILE = NO;
-				APP_DISPLAY_NAME = SpeakType;
+				APP_DISPLAY_NAME = "SpeakType-Dev";
 				INFOPLIST_FILE = speaktype/Resources/Info.plist;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -451,7 +451,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MARKETING_VERSION = 1.1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.2048labs.speaktype;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.2048labs.speaktype.dev";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;


### PR DESCRIPTION
## Why
macOS Accessibility/Microphone permissions are bound to an app's code-signing identity, not just its bundle id. Local Debug builds (Apple Development cert) and the shipped release (Developer ID + notarized) have different designated requirements, so a permission granted to one is not honored by the other. That produced stale/duplicate 'SpeakType' + 'SpeakType-Dev' rows in System Settings that appear on but do not actually grant, and it repeatedly clobbered the release app's permissions during local testing.

## What
- Debug config only: `PRODUCT_BUNDLE_IDENTIFIER = com.2048labs.speaktype.dev`, `APP_DISPLAY_NAME = SpeakType-Dev`.
- Release config unchanged (`com.2048labs.speaktype`, `SpeakType`).
- Entitlements have no app-group/keychain coupling to the bundle id, so nothing else changes.

Now the Dev app is a distinct TCC entity: grant it Accessibility/Mic once and it persists across rebuilds, while the release app's permissions are never touched. Verified: Debug builds as SpeakType-Dev/com.2048labs.speaktype.dev; Release still builds as SpeakType/com.2048labs.speaktype.