### PR TITLE
AI Models: chip/RAM/use-case aware recommendation + hero redesign

### DIFF
--- a/speaktype/Models/AIModel.swift
+++ b/speaktype/Models/AIModel.swift
@@ -147,9 +147,95 @@ struct AIModel: Identifiable, Equatable {
         availableModels.filter { $0.engine == engine }
     }
 
-    /// Returns the best model recommended for this device's RAM
+    /// What the user primarily wants from transcription — biases the trade-off
+    /// between real-time speed and raw accuracy.
+    enum UseCase: String, CaseIterable, Identifiable {
+        case dictation      // real-time typing; latency matters most
+        case balanced
+        case transcription  // files/meetings; accuracy matters most
+
+        var id: String { rawValue }
+
+        var title: String {
+            switch self {
+            case .dictation: return "Dictation"
+            case .balanced: return "Balanced"
+            case .transcription: return "Transcription"
+            }
+        }
+
+        /// (speed, accuracy) weighting, summing to 1.
+        var weights: (speed: Double, accuracy: Double) {
+            switch self {
+            case .dictation: return (0.6, 0.4)
+            case .balanced: return (0.4, 0.6)
+            case .transcription: return (0.2, 0.8)
+            }
+        }
+    }
+
+    /// Recommends the best-fitting model for this Mac and use case, considering
+    /// RAM, chip performance tier, and the Neural Engine — not just RAM.
+    static func recommendedModel(
+        for capability: DeviceCapability = .current,
+        useCase: UseCase = .dictation
+    ) -> AIModel {
+        let fits = availableModels.filter { capability.ramGB >= $0.minimumRAMGB }
+        let pool = fits.isEmpty ? availableModels : fits
+        return pool.max {
+            recommendationScore($0, capability: capability, useCase: useCase)
+                < recommendationScore($1, capability: capability, useCase: useCase)
+        } ?? availableModels.last!
+    }
+
+    /// 0.0–1.0-ish fitness score; higher is a better match for the machine + use case.
+    static func recommendationScore(
+        _ model: AIModel,
+        capability: DeviceCapability,
+        useCase: UseCase
+    ) -> Double {
+        let (wSpeed, wAccuracy) = useCase.weights
+        let speedN = model.speed / 10.0
+        let accuracyN = model.accuracy / 10.0
+
+        // A slow model feels slower on a weaker Mac, so scale perceived speed by
+        // the device tier (weak machines drag large/slow models down).
+        let effectiveSpeed = speedN * (0.5 + 0.5 * capability.performanceTier)
+
+        var score = wSpeed * effectiveSpeed + wAccuracy * accuracyN
+
+        // Lightly reward comfortable RAM headroom so we don't pick a model that
+        // only just fits.
+        let headroom = Double(capability.ramGB - model.minimumRAMGB)
+        score += min(0.1, max(0, headroom) * 0.01)
+
+        // Intel Macs have no Neural Engine and struggle with the largest models.
+        if !capability.hasNeuralEngine && model.expectedSizeBytes > 1_000_000_000 {
+            score -= 0.15
+        }
+
+        return score
+    }
+
+    /// A short, human explanation of why a model is recommended for this Mac.
+    static func recommendationReason(
+        for model: AIModel,
+        capability: DeviceCapability = .current,
+        useCase: UseCase = .dictation
+    ) -> String {
+        let engineNote = model.engine == .parakeet ? "runs in real time" : "loads comfortably"
+        switch useCase {
+        case .dictation:
+            return "Fast, accurate enough for live dictation and \(engineNote) on your \(capability.chipName)."
+        case .balanced:
+            return "A strong balance of speed and accuracy for your \(capability.chipName)."
+        case .transcription:
+            return "Highest accuracy your \(capability.chipName) with \(capability.ramGB) GB can run well."
+        }
+    }
+
+    /// Backward-compatible RAM-only recommendation used by older call sites.
     static func recommendedModel(forDeviceRAMGB ram: Int) -> AIModel {
-        // Find the best (highest accuracy) model that fits in the device's RAM
         return availableModels.first(where: { ram >= $0.minimumRAMGB })
             ?? availableModels.last!  // Fallback to smallest
     }

--- a/speaktype/Models/DeviceCapability.swift
+++ b/speaktype/Models/DeviceCapability.swift
@@ -1,0 +1,131 @@
+//
+//  DeviceCapability.swift
+//  speaktype
+//
+//  Detects the host Mac's hardware so the app can recommend a transcription
+//  model that actually matches the machine — not just its RAM. Considers the
+//  chip family/generation, performance-core count, Neural Engine, and RAM.
+//
+
+import Foundation
+
+/// A snapshot of the host Mac's relevant compute capability.
+struct DeviceCapability: Equatable {
+    enum Chip: Equatable {
+        /// Apple Silicon with a best-effort generation (M1 = 1, M2 = 2, …); 0 if unknown.
+        case appleSilicon(generation: Int)
+        case intel
+        case unknown
+    }
+
+    /// Installed physical memory, in GB.
+    let ramGB: Int
+    let chip: Chip
+    /// Human-readable chip string, e.g. "Apple M3 Pro" or an Intel brand string.
+    let chipName: String
+    /// Number of performance cores (Apple Silicon) or physical cores (Intel).
+    let performanceCoreCount: Int
+    /// Apple Silicon ships a Neural Engine; Intel Macs do not.
+    let hasNeuralEngine: Bool
+
+    /// Cached capability for the current machine.
+    static let current: DeviceCapability = detect()
+
+    /// A 0.0–1.0 estimate of how comfortably this Mac runs a real-time,
+    /// on-device speech model. Higher means larger/slower models stay usable.
+    var performanceTier: Double {
+        let base: Double
+        switch chip {
+        case .appleSilicon(let generation):
+            // M1 ≈ 0.6, and each generation adds headroom, capped at 1.0.
+            base = min(1.0, 0.6 + Double(max(generation - 1, 0)) * 0.12)
+        case .intel:
+            base = 0.3  // No Neural Engine; CoreML falls back to CPU/GPU.
+        case .unknown:
+            base = 0.5
+        }
+        // Extra performance cores widen the margin a little (Pro/Max/Ultra).
+        let coreBonus = min(0.15, Double(max(performanceCoreCount - 4, 0)) * 0.02)
+        return min(1.0, base + coreBonus)
+    }
+
+    var isAppleSilicon: Bool {
+        if case .appleSilicon = chip { return true }
+        return false
+    }
+
+    /// Short summary for UI, e.g. "Apple M3 Pro · 18 GB · Neural Engine".
+    var summary: String {
+        var parts = [chipName, "\(ramGB) GB"]
+        if hasNeuralEngine { parts.append("Neural Engine") }
+        return parts.joined(separator: " · ")
+    }
+
+    // MARK: - Detection
+
+    static func detect() -> DeviceCapability {
+        let ramGB = Int((ProcessInfo.processInfo.physicalMemory + (1 << 29)) / (1 << 30))
+        let brand = sysctlString("machdep.cpu.brand_string") ?? ""
+
+        let chip: Chip
+        let hasNeuralEngine: Bool
+        if brand.localizedCaseInsensitiveContains("Apple") {
+            chip = .appleSilicon(generation: appleSiliconGeneration(from: brand))
+            hasNeuralEngine = true
+        } else if brand.isEmpty {
+            // Empty brand string on Apple Silicon can happen; fall back to arch.
+            #if arch(arm64)
+                chip = .appleSilicon(generation: 0)
+                hasNeuralEngine = true
+            #else
+                chip = .intel
+                hasNeuralEngine = false
+            #endif
+        } else {
+            chip = .intel
+            hasNeuralEngine = false
+        }
+
+        // Performance cores on Apple Silicon live at perflevel0; fall back to
+        // physical CPU count on Intel or older SDKs.
+        let perfCores =
+            sysctlInt("hw.perflevel0.physicalcpu")
+            ?? sysctlInt("hw.physicalcpu")
+            ?? ProcessInfo.processInfo.activeProcessorCount
+
+        let chipName = brand.isEmpty ? (chip == .intel ? "Intel Mac" : "Apple Silicon") : brand
+
+        return DeviceCapability(
+            ramGB: max(ramGB, 1),
+            chip: chip,
+            chipName: chipName,
+            performanceCoreCount: max(perfCores, 1),
+            hasNeuralEngine: hasNeuralEngine
+        )
+    }
+
+    /// Parse the M-series generation from a brand string like "Apple M3 Pro".
+    static func appleSiliconGeneration(from brand: String) -> Int {
+        // Look for the token after "M" (e.g. "M3" -> 3).
+        guard let range = brand.range(of: #"\bM(\d+)"#, options: .regularExpression) else {
+            return 0
+        }
+        let token = brand[range].dropFirst()  // drop the "M"
+        return Int(token) ?? 0
+    }
+
+    private static func sysctlString(_ name: String) -> String? {
+        var size = 0
+        guard sysctlbyname(name, nil, &size, nil, 0) == 0, size > 0 else { return nil }
+        var buffer = [CChar](repeating: 0, count: size)
+        guard sysctlbyname(name, &buffer, &size, nil, 0) == 0 else { return nil }
+        return String(cString: buffer)
+    }
+
+    private static func sysctlInt(_ name: String) -> Int? {
+        var value: Int = 0
+        var size = MemoryLayout<Int>.size
+        guard sysctlbyname(name, &value, &size, nil, 0) == 0 else { return nil }
+        return value
+    }
+}

--- a/speaktype/Views/Screens/Settings/AIModelsView.swift
+++ b/speaktype/Views/Screens/Settings/AIModelsView.swift
@@ -6,12 +6,27 @@ struct AIModelsView: View {
 
     @StateObject private var downloadService = ModelDownloadService.shared
     @AppStorage(ModelSelection.defaultsKey) private var selectedModel: String = ModelSelection.none
+    @AppStorage("modelUseCase") private var useCaseRaw: String = AIModel.UseCase.dictation.rawValue
     @State private var models = AIModel.availableModels
 
     // MARK: - Computed Properties
 
+    private var capability: DeviceCapability { .current }
+
+    private var useCase: AIModel.UseCase {
+        AIModel.UseCase(rawValue: useCaseRaw) ?? .dictation
+    }
+
+    private var recommendedModel: AIModel {
+        AIModel.recommendedModel(for: capability, useCase: useCase)
+    }
+
     var selectedModelName: String {
         models.first(where: { $0.variant == selectedModel })?.name ?? "No model downloaded yet"
+    }
+
+    private func isDownloaded(_ variant: String) -> Bool {
+        (downloadService.downloadProgress[variant] ?? 0) >= 1.0
     }
 
     private var hasAnyModelDownloaded: Bool {
@@ -24,6 +39,8 @@ struct AIModelsView: View {
         ScrollView {
             VStack(alignment: .leading, spacing: 24) {
                 headerSection
+
+                recommendationCard
 
                 // Show setup banner if no model downloaded
                 if !hasAnyModelDownloaded {
@@ -53,28 +70,121 @@ struct AIModelsView: View {
     // MARK: - Subviews
 
     private var headerSection: some View {
-        VStack(alignment: .leading, spacing: 4) {
+        VStack(alignment: .leading, spacing: 6) {
             Text("AI Models")
                 .font(Typography.displayLarge)
                 .foregroundStyle(Color.textPrimary)
 
             HStack(spacing: 6) {
-                let recommended = AIModel.recommendedModel(
-                    forDeviceRAMGB: WhisperService.deviceRAMGB)
-                Text(
-                    "Recommended for your Mac (\(WhisperService.deviceRAMGB)GB RAM): **\(recommended.name)**"
-                )
-                .font(Typography.bodySmall)
-                .foregroundStyle(Color.textSecondary)
-
-                // Info icon with tooltip on hover
-                Image(systemName: "info.circle")
+                Image(systemName: "cpu")
                     .font(.system(size: 12))
                     .foregroundStyle(Color.textMuted)
-                    .help(
-                        "First transcription after selecting a model may take 10-30 seconds while the AI loads."
-                    )
+                Text(capability.summary)
+                    .font(Typography.bodySmall)
+                    .foregroundStyle(Color.textSecondary)
             }
+        }
+    }
+
+    /// Hero card: a use-case picker plus the model we recommend for this Mac,
+    /// re-scored live as the use case changes.
+    private var recommendationCard: some View {
+        let rec = recommendedModel
+        let downloaded = isDownloaded(rec.variant)
+        let isActive = selectedModel == rec.variant
+
+        return VStack(alignment: .leading, spacing: 16) {
+            HStack {
+                Label("Recommended for you", systemImage: "sparkles")
+                    .font(Typography.captionSmall)
+                    .foregroundStyle(Color.textSecondary)
+                    .textCase(.uppercase)
+                    .tracking(0.5)
+                Spacer()
+            }
+
+            // Use-case selector — changes the speed/accuracy trade-off.
+            Picker("", selection: $useCaseRaw) {
+                ForEach(AIModel.UseCase.allCases) { uc in
+                    Text(uc.title).tag(uc.rawValue)
+                }
+            }
+            .pickerStyle(.segmented)
+            .labelsHidden()
+
+            HStack(alignment: .top, spacing: 16) {
+                VStack(alignment: .leading, spacing: 6) {
+                    Text(rec.name)
+                        .font(Typography.headlineMedium)
+                        .foregroundStyle(Color.textPrimary)
+
+                    Text(AIModel.recommendationReason(for: rec, capability: capability, useCase: useCase))
+                        .font(Typography.bodySmall)
+                        .foregroundStyle(Color.textSecondary)
+                        .fixedSize(horizontal: false, vertical: true)
+
+                    HStack(spacing: 14) {
+                        recMeta(
+                            icon: rec.isEnglishOnly ? "character.book.closed" : "globe",
+                            text: rec.languageSupportLabel)
+                        recMeta(icon: "arrow.down.circle", text: rec.size)
+                    }
+                    .padding(.top, 2)
+                    .foregroundStyle(Color.textMuted)
+                }
+
+                Spacer()
+
+                // Primary action reflects current state.
+                if isActive && downloaded {
+                    Label("In use", systemImage: "checkmark.circle.fill")
+                        .font(Typography.buttonLabelSmall)
+                        .foregroundStyle(Color.textSecondary)
+                } else if downloaded {
+                    Button {
+                        selectedModel = rec.variant
+                    } label: {
+                        Text("Use")
+                            .font(Typography.buttonLabelSmall)
+                            .padding(.horizontal, 16)
+                            .padding(.vertical, 8)
+                            .background(Color.white)
+                            .foregroundStyle(Color.black)
+                            .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+                    }
+                    .buttonStyle(.plain)
+                } else {
+                    Button {
+                        downloadService.downloadModel(variant: rec.variant)
+                    } label: {
+                        Label("Download", systemImage: "arrow.down")
+                            .font(Typography.buttonLabelSmall)
+                            .padding(.horizontal, 16)
+                            .padding(.vertical, 8)
+                            .background(Color.white)
+                            .foregroundStyle(Color.black)
+                            .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+        }
+        .padding(20)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Color.bgCard)
+        .clipShape(RoundedRectangle(cornerRadius: 16))
+        .overlay(
+            RoundedRectangle(cornerRadius: 16)
+                .stroke(Color.textPrimary.opacity(0.25), lineWidth: 1)
+        )
+    }
+
+    private func recMeta(icon: String, text: String) -> some View {
+        HStack(spacing: 4) {
+            Image(systemName: icon)
+                .font(.system(size: 11))
+            Text(text)
+                .font(Typography.cardMeta)
         }
     }
 
@@ -127,7 +237,7 @@ struct AIModelsView: View {
                     .foregroundStyle(Color.textPrimary)
 
                 Text(
-                    "Choose a model below to enable voice transcription. We recommend **\(AIModel.recommendedModel(forDeviceRAMGB: WhisperService.deviceRAMGB).name)** for your Mac."
+                    "Choose a model below to enable voice transcription. We recommend **\(recommendedModel.name)** for your \(capability.chipName)."
                 )
                 .font(.system(size: 13))
                 .foregroundStyle(Color.textSecondary)


### PR DESCRIPTION
First pass of the AI Models upgrade: a smarter recommendation engine plus a redesigned header/hero that surfaces it.

## Smarter engine
- **New `DeviceCapability`** detects the actual machine, not just RAM: chip family + Apple Silicon generation, performance-core count, Neural Engine, and RAM (via sysctl), and derives a 0–1 performance tier.
- **Scoring-based recommendation** replaces the old 'first model that fits RAM':
  - weighs speed vs accuracy by **use case** (Dictation / Balanced / Transcription),
  - scales perceived speed by the device tier (a slow model is penalized more on a weaker Mac),
  - rewards comfortable RAM headroom,
  - penalizes the largest models on Neural-Engine-less Intel Macs.
- Old `recommendedModel(forDeviceRAMGB:)` kept as a compatibility wrapper.

## UI
- Header now shows the detected Mac (e.g. `Apple M3 Pro · 18 GB · Neural Engine`).
- New **recommendation hero card**: a live segmented **use-case picker** that re-scores the pick, the recommended model with a plain-language reason, and a **Use/Download/In use** action.

## Testing
- `xcodebuild build` (Debug) succeeds.
- Recommendation logic is pure/deterministic and unit-testable — happy to add tests for the scoring if you want.

## Scope note
This is phase 1 (engine + hero + device-aware header). Deeper visual polish (grouping the list by engine, a 'Recommended' badge on the matching row, richer per-model cards) can follow once you've eyeballed this direction.