### PR TITLE
Fix stale build timestamp in debug version label

### DIFF
--- a/speaktype/Constants/BuildInfo.swift
+++ b/speaktype/Constants/BuildInfo.swift
@@ -1,2 +1,18 @@
-// Auto-generated — do not edit manually.
-let buildTimestamp = "Mar 24 13:55:54"
+import Foundation
+
+/// Build timestamp shown in the debug version label. Derived at runtime from the
+/// app binary's build date so it always reflects the actual build — the old
+/// hardcoded constant never updated because nothing regenerated it.
+let buildTimestamp: String = {
+    let formatter = DateFormatter()
+    formatter.locale = Locale(identifier: "en_US_POSIX")
+    formatter.dateFormat = "MMM d HH:mm:ss"
+
+    let path = Bundle.main.executableURL?.path ?? Bundle.main.bundlePath
+    if let date = try? FileManager.default.attributesOfItem(atPath: path)[.modificationDate]
+        as? Date
+    {
+        return formatter.string(from: date)
+    }
+    return "unknown"
+}()


### PR DESCRIPTION
## Problem
The debug version label showed `v1.1.0 (Mar 24 13:55:54)` on every build. The version (1.1.0) is correct, but the date was wrong: `BuildInfo.swift` held a hardcoded `buildTimestamp = "Mar 24 13:55:54"`. The file was labeled 'auto-generated' but no build-phase script ever regenerated it, so it stayed frozen at whenever it was last hand-generated.

## Fix
Derive `buildTimestamp` at runtime from the app binary's modification (build) date, so it always reflects the actual build with no generator to forget. Only surfaced in the DEBUG-only version label.

Builds clean.