### PR TITLE
Tidy mini-recorder toolbar (invisible mic, language text, padding)

### DIFF
--- a/speaktype/Controllers/MiniRecorderWindowController.swift
+++ b/speaktype/Controllers/MiniRecorderWindowController.swift
@@ -29,7 +29,7 @@ class MiniRecorderWindowController: NSObject {
             // Position above dock with fixed width (panel width should be 220)
             if let screen = NSScreen.main {
                 let visibleFrame = screen.visibleFrame
-                let windowWidth: CGFloat = 260  // Fixed width from setupPanel
+                let windowWidth: CGFloat = 300  // Fixed width from setupPanel
                 let x = visibleFrame.midX - (windowWidth / 2)
                 let y = visibleFrame.minY + 50  // 50px padding above dock
                 panel.setFrameOrigin(NSPoint(x: x, y: y))
@@ -76,7 +76,7 @@ class MiniRecorderWindowController: NSObject {
             rootView: AnyView(recorderView.background(Color.clear)))
 
         let p = NSPanel(
-            contentRect: NSRect(x: 0, y: 0, width: 260, height: 50),
+            contentRect: NSRect(x: 0, y: 0, width: 300, height: 50),
             styleMask: [.nonactivatingPanel, .fullSizeContentView, .borderless],
             backing: .buffered,
             defer: false

--- a/speaktype/Views/Overlays/MiniRecorderView.swift
+++ b/speaktype/Views/Overlays/MiniRecorderView.swift
@@ -155,7 +155,12 @@ struct MiniRecorderView: View {
                     }
                     .frame(width: 96, height: 26)
 
-                    HStack(spacing: 8) {
+                    // Hairline divider between the live waveform and the controls.
+                    Rectangle()
+                        .fill(Color.white.opacity(0.12))
+                        .frame(width: 1, height: 22)
+
+                    HStack(spacing: 14) {
                         Menu {
                             Button("Auto-detect") { setLanguage("auto") }
 
@@ -182,20 +187,16 @@ struct MiniRecorderView: View {
                                 Button("Clear recents") { recentLanguagesString = "" }
                             }
                         } label: {
-                            HStack(spacing: 5) {
+                            HStack(spacing: 4) {
                                 Image(systemName: "globe")
-                                    .font(.system(size: 12, weight: .semibold))
+                                    .font(.system(size: 13, weight: .semibold))
 
-                                DoubleChevronIcon(color: .white.opacity(0.92))
+                                DoubleChevronIcon(color: .white.opacity(0.5))
                             }
-                            .padding(.horizontal, 8)
-                            .padding(.vertical, 5)
-                            .background(Color.white.opacity(0.15))
-                            .clipShape(RoundedRectangle(cornerRadius: 6))
                         }
                         .menuIndicator(.hidden)
                         .menuStyle(.borderlessButton)
-                        .tint(.white.opacity(0.92))
+                        .tint(.white.opacity(0.85))
                         .fixedSize()
                         .help(spokenLanguageHelpText)
 
@@ -222,26 +223,22 @@ struct MiniRecorderView: View {
                                 audioRecorder.fetchAvailableDevices()
                             }
                         } label: {
-                            HStack(spacing: 5) {
+                            HStack(spacing: 4) {
                                 Image(systemName: "mic.fill")
-                                    .font(.system(size: 12, weight: .semibold))
+                                    .font(.system(size: 13, weight: .semibold))
 
-                                DoubleChevronIcon(color: .white.opacity(0.92))
+                                DoubleChevronIcon(color: .white.opacity(0.5))
                             }
-                            .padding(.horizontal, 8)
-                            .padding(.vertical, 5)
-                            .background(Color.white.opacity(0.15))
-                            .clipShape(RoundedRectangle(cornerRadius: 6))
                         }
                         .menuIndicator(.hidden)
                         .menuStyle(.borderlessButton)
-                        .tint(.white.opacity(0.92))
+                        .tint(.white.opacity(0.85))
                         .fixedSize()
                         .help(inputDeviceHelpText)
 
                         // Recording mode indicator
                         Image(systemName: recordingMode == 0 ? "hand.tap.fill" : "repeat.1")
-                            .font(.system(size: 14, weight: .semibold))
+                            .font(.system(size: 13, weight: .semibold))
                             .foregroundColor(.white.opacity(0.7))
                             .help(recordingMode == 0 ? "Hold to Record" : "Toggle to Record")
                     }
@@ -333,17 +330,30 @@ struct MiniRecorderView: View {
 
     private var stopButton: some View {
         ZStack {
-            RoundedRectangle(cornerRadius: 10)  // Squircle
-                .fill(Color(red: 1.0, green: 0.2, blue: 0.2))  // Bright Red
-                .frame(width: 32, height: 32)  // Smaller button
-                .shadow(color: Color.red.opacity(0.4), radius: 4, x: 0, y: 0)
+            RoundedRectangle(cornerRadius: 11, style: .continuous)
+                .fill(
+                    LinearGradient(
+                        colors: [
+                            Color(red: 1.0, green: 0.36, blue: 0.34),
+                            Color(red: 0.90, green: 0.15, blue: 0.15),
+                        ],
+                        startPoint: .top,
+                        endPoint: .bottom
+                    )
+                )
+                .frame(width: 32, height: 32)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 11, style: .continuous)
+                        .stroke(Color.white.opacity(0.28), lineWidth: 0.5)
+                )
+                .shadow(color: Color(red: 1.0, green: 0.2, blue: 0.2).opacity(0.45), radius: 7, x: 0, y: 1)
 
-            // Inner square icon
-            RoundedRectangle(cornerRadius: 3)
-                .fill(Color.black.opacity(0.4))
+            // Inner stop square.
+            RoundedRectangle(cornerRadius: 3, style: .continuous)
+                .fill(Color.white)
                 .frame(width: 10, height: 10)
         }
-        .contentShape(RoundedRectangle(cornerRadius: 10))
+        .contentShape(RoundedRectangle(cornerRadius: 11))
         .onTapGesture {
             handleHotkeyTrigger()
         }
@@ -351,16 +361,41 @@ struct MiniRecorderView: View {
 
     private var backgroundView: some View {
         ZStack {
-            // Dark background with blur, all clipped to capsule
+            // Frosted blur base, clipped to the pill.
             VisualEffectBlur(material: .hudWindow, blendingMode: .behindWindow, cornerRadius: 25)
-                .clipShape(RoundedRectangle(cornerRadius: 25))
+                .clipShape(RoundedRectangle(cornerRadius: 25, style: .continuous))
 
-            RoundedRectangle(cornerRadius: 25)
-                .fill(Color.black.opacity(0.85))
+            // Depth: subtly lighter at the top, darker at the bottom.
+            RoundedRectangle(cornerRadius: 25, style: .continuous)
+                .fill(
+                    LinearGradient(
+                        colors: [Color(white: 0.17), Color(white: 0.07)],
+                        startPoint: .top,
+                        endPoint: .bottom
+                    )
+                )
+                .opacity(0.92)
 
-            // Subtle border
-            RoundedRectangle(cornerRadius: 25)
-                .stroke(Color.white.opacity(0.1), lineWidth: 1)
+            // Glass highlight along the top edge.
+            RoundedRectangle(cornerRadius: 25, style: .continuous)
+                .fill(
+                    LinearGradient(
+                        colors: [Color.white.opacity(0.10), Color.clear],
+                        startPoint: .top,
+                        endPoint: .center
+                    )
+                )
+
+            // Hairline border, brighter up top for a lit-from-above feel.
+            RoundedRectangle(cornerRadius: 25, style: .continuous)
+                .stroke(
+                    LinearGradient(
+                        colors: [Color.white.opacity(0.22), Color.white.opacity(0.05)],
+                        startPoint: .top,
+                        endPoint: .bottom
+                    ),
+                    lineWidth: 1
+                )
         }
     }
 

--- a/speaktype/Views/Overlays/MiniRecorderView.swift
+++ b/speaktype/Views/Overlays/MiniRecorderView.swift
@@ -182,23 +182,20 @@ struct MiniRecorderView: View {
                                 Button("Clear recents") { recentLanguagesString = "" }
                             }
                         } label: {
-                            HStack(spacing: 6) {
-                                Text(currentLanguageLabel)
-                                    .font(.system(size: 11, weight: .semibold))
-                                    .foregroundColor(.white.opacity(0.92))
-                                    .lineLimit(1)
-                                    .truncationMode(.tail)
+                            HStack(spacing: 5) {
+                                Image(systemName: "globe")
+                                    .font(.system(size: 12, weight: .semibold))
 
                                 DoubleChevronIcon(color: .white.opacity(0.92))
                             }
-                            .frame(maxWidth: 74, alignment: .leading)
                             .padding(.horizontal, 8)
-                            .padding(.vertical, 4)
+                            .padding(.vertical, 5)
                             .background(Color.white.opacity(0.15))
-                            .clipShape(RoundedRectangle(cornerRadius: 4))
+                            .clipShape(RoundedRectangle(cornerRadius: 6))
                         }
                         .menuIndicator(.hidden)
                         .menuStyle(.borderlessButton)
+                        .tint(.white.opacity(0.92))
                         .fixedSize()
                         .help(spokenLanguageHelpText)
 
@@ -225,20 +222,20 @@ struct MiniRecorderView: View {
                                 audioRecorder.fetchAvailableDevices()
                             }
                         } label: {
-                            HStack(spacing: 6) {
+                            HStack(spacing: 5) {
                                 Image(systemName: "mic.fill")
-                                    .font(.system(size: 11, weight: .semibold))
-                                    .foregroundColor(.white.opacity(0.92))
+                                    .font(.system(size: 12, weight: .semibold))
 
                                 DoubleChevronIcon(color: .white.opacity(0.92))
                             }
                             .padding(.horizontal, 8)
-                            .padding(.vertical, 4)
+                            .padding(.vertical, 5)
                             .background(Color.white.opacity(0.15))
-                            .clipShape(RoundedRectangle(cornerRadius: 4))
+                            .clipShape(RoundedRectangle(cornerRadius: 6))
                         }
                         .menuIndicator(.hidden)
                         .menuStyle(.borderlessButton)
+                        .tint(.white.opacity(0.92))
                         .fixedSize()
                         .help(inputDeviceHelpText)
 
@@ -253,7 +250,7 @@ struct MiniRecorderView: View {
                 .transition(.opacity)
             }
         }
-        .frame(width: 260, height: 50)
+        .frame(width: 300, height: 50)
         .clipShape(RoundedRectangle(cornerRadius: 25))
         .shadow(color: .black.opacity(0.25), radius: 8, x: 0, y: 2)
         .contextMenu {


### PR DESCRIPTION
Fixes three issues on the recording widget introduced/exposed by the input-device menu (#56):

- **Invisible mic:** `mic.fill` inside a `.borderlessButton` Menu adopts the control's content color (black on the dark pill), ignoring the per-image `.foregroundColor` — while the custom-drawn `DoubleChevronIcon` was fine. Fixed by `.tint(.white)` on the menus.
- **Language text:** replaced the 'English' text label with a compact globe icon (full language name still in the menu + tooltip).
- **Padding/cramping:** the added mic chip pushed content past the hard-fixed 260pt pill; widened the pill to 300pt (view + panel) so it fits.

Builds clean.