### PR TITLE
Fix mic going silent after display or input device changes

### DIFF
--- a/speaktype/Services/AudioRecordingService.swift
+++ b/speaktype/Services/AudioRecordingService.swift
@@ -44,6 +44,9 @@ class AudioRecordingService: NSObject, ObservableObject {
     /// Tracks the last macOS system default input UID so we can follow default changes
     /// when the user has not explicitly picked a different device in SpeakType settings.
     private var lastKnownSystemDefaultInputUID: String?
+    /// Retained so the Core Audio default-input listener can be removed on deinit.
+    /// AudioObjectRemovePropertyListenerBlock requires the *same* block instance.
+    private var defaultInputListenerBlock: AudioObjectPropertyListenerBlock?
 
     // MARK: - Chunking state
     private var chunkAssetWriter: AVAssetWriter?
@@ -191,17 +194,43 @@ class AudioRecordingService: NSObject, ObservableObject {
             mElement: kAudioObjectPropertyElementMain
         )
 
-        let status = AudioObjectAddPropertyListenerBlock(
-            AudioObjectID(kAudioObjectSystemObject),
-            &address,
-            DispatchQueue.main
-        ) { [weak self] _, _ in
+        let block: AudioObjectPropertyListenerBlock = { [weak self] _, _ in
             self?.handleSystemDefaultInputChanged()
         }
 
-        if status != noErr {
+        let status = AudioObjectAddPropertyListenerBlock(
+            AudioObjectID(kAudioObjectSystemObject),
+            &address,
+            DispatchQueue.main,
+            block
+        )
+
+        if status == noErr {
+            defaultInputListenerBlock = block
+        } else {
             print("Failed to observe system default input device: \(status)")
         }
+    }
+
+    private func stopObservingDefaultInputDevice() {
+        guard let block = defaultInputListenerBlock else { return }
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioHardwarePropertyDefaultInputDevice,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain
+        )
+        AudioObjectRemovePropertyListenerBlock(
+            AudioObjectID(kAudioObjectSystemObject),
+            &address,
+            DispatchQueue.main,
+            block
+        )
+        defaultInputListenerBlock = nil
+    }
+
+    deinit {
+        stopObservingDefaultInputDevice()
+        NotificationCenter.default.removeObserver(self)
     }
 
     func fetchAvailableDevices(completion: (() -> Void)? = nil) {
@@ -287,9 +316,17 @@ class AudioRecordingService: NSObject, ObservableObject {
     private func restartCaptureSession() {
         audioQueue.async {
             self.cancelIdleSessionStop()
-            guard let session = self.captureSession, !session.isRunning else { return }
-            print("🎤 Restarting capture session after reconfiguration...")
-            session.startRunning()
+            if let session = self.captureSession, !session.isRunning {
+                print("🎤 Restarting capture session after reconfiguration...")
+                session.startRunning()
+            }
+            // If this restart was for a pre-warmed (idle) session rather than an
+            // active recording, re-arm the idle auto-stop. Otherwise the mic would
+            // stay hot indefinitely after a device/route change, regressing the
+            // "no continuous mic indicator while idle" behavior.
+            if !self.isRecording {
+                self.scheduleIdleSessionStop()
+            }
         }
     }
 

--- a/speaktype/Services/AudioRecordingService.swift
+++ b/speaktype/Services/AudioRecordingService.swift
@@ -1,5 +1,6 @@
 import AVFoundation
 import Combine
+import CoreAudio
 import CoreMedia
 import Foundation
 
@@ -40,6 +41,9 @@ class AudioRecordingService: NSObject, ObservableObject {
     private var setupTask: Task<Void, Never>?
     private var isStopping = false  // Flag to prevent appending during stop
     private var idleSessionStopWorkItem: DispatchWorkItem?
+    /// Tracks the last macOS system default input UID so we can follow default changes
+    /// when the user has not explicitly picked a different device in SpeakType settings.
+    private var lastKnownSystemDefaultInputUID: String?
 
     // MARK: - Chunking state
     private var chunkAssetWriter: AVAssetWriter?
@@ -143,14 +147,64 @@ class AudioRecordingService: NSObject, ObservableObject {
             name: AVCaptureDevice.wasDisconnectedNotification,
             object: nil
         )
+
+        lastKnownSystemDefaultInputUID = Self.defaultInputDeviceUID()
+        startObservingDefaultInputDevice()
     }
 
     @objc private func handleDeviceChange(_ notification: Notification) {
         print("Audio device change detected")
-        fetchAvailableDevices()
+        fetchAvailableDevices { [weak self] in
+            // Rebuild even when selectedDeviceId is unchanged — display reconnects and
+            // route changes can leave the old AVCaptureSession alive but silent.
+            self?.recoverCaptureSessionIfNeeded(forceReconfigure: true)
+        }
     }
 
-    func fetchAvailableDevices() {
+    private func handleSystemDefaultInputChanged() {
+        let previousDefault = lastKnownSystemDefaultInputUID
+        guard let newDefaultUID = Self.defaultInputDeviceUID() else { return }
+        lastKnownSystemDefaultInputUID = newDefaultUID
+
+        fetchAvailableDevices { [weak self] in
+            guard let self else { return }
+
+            // If the app was effectively using the previous system default, follow the
+            // new default when the user changes input in System Settings.
+            if let previousDefault,
+                self.selectedDeviceId == previousDefault,
+                newDefaultUID != previousDefault,
+                self.availableDevices.contains(where: { $0.uniqueID == newDefaultUID })
+            {
+                print("🎤 Following system default input change to UID: \(newDefaultUID)")
+                self.selectedDeviceId = newDefaultUID
+            } else {
+                self.recoverCaptureSessionIfNeeded(forceReconfigure: true)
+            }
+        }
+    }
+
+    private func startObservingDefaultInputDevice() {
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioHardwarePropertyDefaultInputDevice,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain
+        )
+
+        let status = AudioObjectAddPropertyListenerBlock(
+            AudioObjectID(kAudioObjectSystemObject),
+            &address,
+            DispatchQueue.main
+        ) { [weak self] _, _ in
+            self?.handleSystemDefaultInputChanged()
+        }
+
+        if status != noErr {
+            print("Failed to observe system default input device: \(status)")
+        }
+    }
+
+    func fetchAvailableDevices(completion: (() -> Void)? = nil) {
         let discoverySession = AVCaptureDevice.DiscoverySession(
             deviceTypes: [.microphone],
             mediaType: .audio,
@@ -174,10 +228,12 @@ class AudioRecordingService: NSObject, ObservableObject {
                     self.selectedDeviceId = nil
                 }
             }
+            completion?()
         }
     }
 
     func setupSession() {
+        let shouldRestart = isRecording || (captureSession?.isRunning ?? false)
         captureSession?.stopRunning()
         captureSession = AVCaptureSession()
 
@@ -215,6 +271,62 @@ class AudioRecordingService: NSObject, ObservableObject {
 
         // Don't start session here - only start when recording begins
         // This prevents continuous CPU usage when idle
+        if shouldRestart {
+            restartCaptureSession()
+        }
+    }
+
+    /// Rebuild and restart the capture session after hardware/route changes.
+    private func recoverCaptureSessionIfNeeded(forceReconfigure: Bool = false) {
+        let shouldRecover =
+            forceReconfigure || isRecording || (captureSession?.isRunning ?? false)
+        guard shouldRecover else { return }
+        setupSession()
+    }
+
+    private func restartCaptureSession() {
+        audioQueue.async {
+            self.cancelIdleSessionStop()
+            guard let session = self.captureSession, !session.isRunning else { return }
+            print("🎤 Restarting capture session after reconfiguration...")
+            session.startRunning()
+        }
+    }
+
+    private static func defaultInputDeviceUID() -> String? {
+        var deviceID = AudioDeviceID(0)
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioHardwarePropertyDefaultInputDevice,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain
+        )
+        var size = UInt32(MemoryLayout<AudioDeviceID>.size)
+        guard
+            AudioObjectGetPropertyData(
+                AudioObjectID(kAudioObjectSystemObject),
+                &address,
+                0,
+                nil,
+                &size,
+                &deviceID
+            ) == noErr
+        else { return nil }
+        return deviceUID(for: deviceID)
+    }
+
+    private static func deviceUID(for deviceID: AudioDeviceID) -> String? {
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioDevicePropertyDeviceUID,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain
+        )
+        var uid = "" as CFString
+        var size = UInt32(MemoryLayout<CFString>.size)
+        let status = withUnsafeMutablePointer(to: &uid) { uidPointer in
+            AudioObjectGetPropertyData(deviceID, &address, 0, nil, &size, uidPointer)
+        }
+        guard status == noErr else { return nil }
+        return uid as String
     }
 
     /// Pre-warm the capture session so first recording starts instantly


### PR DESCRIPTION
## Summary

Fixes a bug where the microphone stops picking up audio after switching monitors/displays, plugging/unplugging input devices, or changing the default input in macOS System Settings — even though the app still appears to be recording.

The root cause is in `AudioRecordingService`: the `AVCaptureSession` was being torn down without being restarted, and hardware route changes were not triggering a session recovery when the selected device ID stayed the same.

## Root cause

Three separate gaps combined to produce the reported behavior:

### 1. `setupSession()` stopped the capture session but never restarted it

`selectedDeviceId`'s `didSet` calls `setupSession()`, which runs `captureSession?.stopRunning()` and rebuilds inputs/outputs — but intentionally does **not** call `startRunning()` (to avoid keeping the mic hot while idle).

That is correct for idle state, but broken when a session rebuild happens **during an active recording** or while a pre-warmed session is running. The session is left configured but stopped, so no audio buffers arrive and the waveform flatlines.

### 2. Plug/unplug notifications did not recover stale sessions

`handleDeviceChange` only called `fetchAvailableDevices()`. If the selected device's `uniqueID` did not change (common when reconnecting a display with HDMI/DisplayPort audio, or when macOS re-enumerates devices without changing the UID), `setupSession()` was never invoked and the existing `AVCaptureSession` could remain alive-but-silent.

### 3. System Settings input changes were ignored

SpeakType persists a specific `selectedDeviceId` in UserDefaults. Changing the default input in **System Settings → Sound → Input** does not fire `AVCaptureDevice` connect/disconnect notifications, so the app kept capturing from the old pinned device. Users reasonably expect System Settings changes to take effect.

## Fix

All changes are in `speaktype/Services/AudioRecordingService.swift`:

1. **Restart after reconfiguration** — `setupSession()` now records whether the session was running or a recording was active before teardown, and calls `restartCaptureSession()` on `audioQueue` when either is true.

2. **Recover on hardware route changes** — `handleDeviceChange` now calls `recoverCaptureSessionIfNeeded(forceReconfigure: true)` after refreshing the device list, forcing a rebuild even when `selectedDeviceId` is unchanged.

3. **Follow macOS default input changes** — Added a Core Audio property listener on `kAudioHardwarePropertyDefaultInputDevice`. When the system default changes:
   - If the app's current selection matched the *previous* system default, it follows the new default (so System Settings changes work as expected).
   - Otherwise it rebuilds/restarts the session in place (preserving an explicit in-app device choice).

## Test plan

- [ ] Start recording with the built-in mic; confirm waveform and transcription work.
- [ ] While recording, switch to an external monitor (or unplug/replug one) and confirm audio continues without restarting the app.
- [ ] While recording, plug/unplug a USB microphone or headset and confirm capture recovers (or falls back to the next available device).
- [ ] Change the default input in System Settings while the app is using that device; confirm the app follows the new default on the next recording (or mid-recording if applicable).
- [ ] Explicitly select a non-default device in SpeakType Settings; change System Settings default to a different device; confirm SpeakType keeps the explicitly chosen device.
- [ ] Confirm the mic indicator is not lit continuously while idle (no regression from pre-warm behavior).
