### PR TITLE
ci: build on macos-26 so the macOS 26 SDK (.glassEffect) is available

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ concurrency:
 jobs:
   build-and-test:
     name: Build & Unit Test
-    runs-on: macos-15
+    runs-on: macos-26
     steps:
       - uses: actions/checkout@v4
 
@@ -38,7 +38,7 @@ jobs:
 
   lint:
     name: SwiftLint
-    runs-on: macos-15
+    runs-on: macos-26
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Problem
Main CI has been **red on every commit** since the recorder pill adopted native Liquid Glass. The `Build (Debug)` step fails with:

```
MiniRecorderView.swift:572:22: error: value of type 'Color' has no member 'glassEffect'
MiniRecorderView.swift:572:35: error: cannot infer contextual base in reference to member 'regular'
```

`.glassEffect(...)` is a **macOS 26 SDK** API (Xcode 26). The runner was `macos-15` (Xcode 16.4), whose SDK doesn't contain the symbol, so the build can't compile. A runtime `#available` guard doesn't help — the symbol is absent at compile time in the older SDK.

## Fix
Bump both CI jobs to `macos-26` (Xcode 26), matching the toolchain the app is already developed against locally.

## Notes
- This is the prerequisite for the other open PRs (Dictionary, #100, #101) to show green — they'll build once this merges and they pick up the new runner.
- SwiftLint stays advisory (`continue-on-error: true`); this PR does not touch the lint backlog.