### PR TITLE
fix: recorder widget doesn't hide when not in use (#100)

### DIFF
--- a/speaktype/App/AppDelegate.swift
+++ b/speaktype/App/AppDelegate.swift
@@ -17,8 +17,18 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         miniRecorderController = MiniRecorderWindowController()
-        // Show the always-present resting pill so the recorder lives on screen.
+        // Prepare the resting pill. It stays hidden until recording unless the
+        // user opts into always showing it (issue #100).
         miniRecorderController?.showIdleRecorder()
+
+        // React to the "always show recorder pill" toggle at runtime.
+        NotificationCenter.default.addObserver(
+            forName: .recorderIdleVisibilityChanged,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            self?.miniRecorderController?.applyIdleVisibilityPreference()
+        }
 
         // Only show the Dock icon while the dashboard is actually open; otherwise
         // live quietly in the menu bar.

--- a/speaktype/Constants/Shortcuts+Extensions.swift
+++ b/speaktype/Constants/Shortcuts+Extensions.swift
@@ -11,4 +11,7 @@ extension Notification.Name {
     static let recordingStartRequested = Notification.Name("recordingStartRequested")
     static let recordingStopRequested = Notification.Name("recordingStopRequested")
     static let recordingCancelRequested = Notification.Name("recordingCancelRequested")
+    /// Posted when the "always show recorder pill" preference changes so the
+    /// window controller can show/hide the idle pill immediately.
+    static let recorderIdleVisibilityChanged = Notification.Name("recorderIdleVisibilityChanged")
 }

--- a/speaktype/Controllers/MiniRecorderWindowController.swift
+++ b/speaktype/Controllers/MiniRecorderWindowController.swift
@@ -9,8 +9,15 @@ class MiniRecorderWindowController: NSObject {
         UserDefaults.standard.object(forKey: "restoreClipboardAfterAutoPaste") as? Bool ?? true
     }
 
-    /// Show the always-present resting pill. Called once at launch; the pill then
-    /// lives on screen and morphs into the recording HUD on demand.
+    /// When on, the resting pill stays on screen even when idle. Default off:
+    /// the recorder appears only while dictating and hides afterward (issue #100).
+    private var alwaysShowIdlePill: Bool {
+        UserDefaults.standard.bool(forKey: "alwaysShowRecorderPill")
+    }
+
+    /// Prepare the resting pill. Called once at launch. When "always show" is on
+    /// the pill lives on screen and morphs into the recording HUD; when off it
+    /// stays hidden until recording starts.
     func showIdleRecorder() {
         if panel == nil {
             setupPanel()
@@ -22,8 +29,28 @@ class MiniRecorderWindowController: NSObject {
         // behind it so the transparent window never blocks the desktop or dock.
         panel.ignoresMouseEvents = true
 
-        if !panel.isVisible {
+        if alwaysShowIdlePill, !panel.isVisible {
             panel.orderFrontRegardless()
+        }
+    }
+
+    /// React to the "always show recorder pill" preference changing at runtime.
+    func applyIdleVisibilityPreference() {
+        if panel == nil {
+            setupPanel()
+        }
+        guard let panel = panel else { return }
+
+        if alwaysShowIdlePill {
+            centerPanel()
+            panel.ignoresMouseEvents = true
+            if !panel.isVisible {
+                panel.orderFrontRegardless()
+            }
+        } else if panel.ignoresMouseEvents {
+            // Only hide when idle — during an active session the panel is
+            // interactive (ignoresMouseEvents == false), so leave it alone.
+            panel.orderOut(nil)
         }
     }
 
@@ -68,9 +95,14 @@ class MiniRecorderWindowController: NSObject {
         }
     }
 
-    /// Return the pill to its passive resting state without hiding it.
+    /// Return the pill to its passive resting state. When "always show" is off
+    /// (the default) this hides the recorder so it only appears while dictating.
     private func returnToIdle() {
-        panel?.ignoresMouseEvents = true
+        guard let panel = panel else { return }
+        panel.ignoresMouseEvents = true
+        if !alwaysShowIdlePill {
+            panel.orderOut(nil)
+        }
     }
 
     // Stop recording - trigger transcription and paste

--- a/speaktype/Views/Screens/Settings/SettingsView.swift
+++ b/speaktype/Views/Screens/Settings/SettingsView.swift
@@ -92,6 +92,7 @@ struct GeneralSettingsTab: View {
     @AppStorage("restoreClipboardAfterAutoPaste") private var restoreClipboardAfterAutoPaste =
         true
     @AppStorage("showMenuBarIcon") private var showMenuBarIcon: Bool = true
+    @AppStorage("alwaysShowRecorderPill") private var alwaysShowRecorderPill: Bool = false
     @AppStorage("transcriptionLanguage") private var transcriptionLanguage: String = "auto"
     @AppStorage("recentTranscriptionLanguages") private var recentLanguagesString: String = ""
     @AppStorage("enableAutoEdit") private var enableAutoEdit: Bool = false
@@ -226,6 +227,29 @@ struct GeneralSettingsTab: View {
                                 restoreClipboardAfterAutoPaste
                                     ? "After SpeakType pastes into the active app, it restores whatever was already on your clipboard."
                                     : "After SpeakType pastes into the active app, the transcript stays on your clipboard for manual pasting."
+                            )
+                            .font(Typography.captionSmall)
+                            .foregroundStyle(Color.textMuted)
+                        }
+
+                        VStack(alignment: .leading, spacing: 6) {
+                            HStack {
+                                Text("Always show recorder pill")
+                                    .font(Typography.bodyMedium)
+                                    .foregroundStyle(Color.textPrimary)
+                                Spacer()
+                                Toggle("", isOn: $alwaysShowRecorderPill)
+                                    .labelsHidden()
+                                    .onChange(of: alwaysShowRecorderPill) {
+                                        NotificationCenter.default.post(
+                                            name: .recorderIdleVisibilityChanged, object: nil)
+                                    }
+                            }
+
+                            Text(
+                                alwaysShowRecorderPill
+                                    ? "The small floating recorder stays on screen even when you're not dictating."
+                                    : "The floating recorder appears only while you're dictating and hides when idle."
                             )
                             .font(Typography.captionSmall)
                             .foregroundStyle(Color.textMuted)


### PR DESCRIPTION
Fixes #100.

## Cause
The recorder redesign turned the pill into an **always-present** widget: `showIdleRecorder()` shows it at launch and `returnToIdle()` deliberately keeps it on screen. So it never disappears in either recording mode — as multiple users reported.

## Fix
Restore **hide-when-idle as the default**, and gate the always-visible behavior behind a new opt-in setting.

- **Settings → General → "Always show recorder pill"** (default **off**):
  - **Off:** the recorder appears only while dictating and hides when idle.
  - **On:** the previous always-present pill.
- `returnToIdle()` now `orderOut()`s the panel when the toggle is off (runs after commit *and* after cancel / no-speech). Recording still shows the HUD via `startRecording()`.
- `showIdleRecorder()` only fronts the pill at launch when the toggle is on.
- Flipping the setting posts `.recorderIdleVisibilityChanged`; `AppDelegate` observes it and calls `applyIdleVisibilityPreference()` to show/hide immediately (guards against hiding mid-session via the panel's interactive state).

## Notes
- CI here will be red until #104 (macos-26 runner) merges — pre-existing `.glassEffect` SDK issue, unrelated to this change.

## Test plan
- Default: pill absent on launch → appears on record → hides after paste. Works in both Hold and Toggle modes.
- Turn the setting on → pill stays resting on screen; off → hides again immediately.