### PR TITLE
fix: clearAll() leaks audio files (#101)

### DIFF
--- a/speaktype/Services/HistoryService.swift
+++ b/speaktype/Services/HistoryService.swift
@@ -90,6 +90,10 @@ class HistoryService: ObservableObject {
     }
     
     func clearAll() {
+        // Delete the audio files backing every transcript so they don't leak on
+        // disk (matches `deleteItem`'s `deleteAudioFile: true` default). Stats are
+        // intentionally preserved — the Clear All dialog promises to keep them.
+        items.forEach(removeAudioFileIfNeeded(for:))
         items.removeAll()
         saveHistory()
     }


### PR DESCRIPTION
Fixes #101.

## Problem
`HistoryService.clearAll()` removed transcript items but left their backing audio files on disk forever, so "Clear All" silently leaked storage:

```swift
func clearAll() {
    items.removeAll()
    saveHistory()
}
```

## Fix
Delete each item's audio file before clearing, reusing the existing `removeAudioFileIfNeeded(for:)` — the same thing `deleteItem` does by default.

## Deliberately *not* changed: stats
The issue also expected `statsEntries` to reset. I left stats intact on purpose: the Clear All confirmation dialog explicitly says **"This removes your saved transcripts, but keeps your statistics history."** Resetting stats would contradict that documented promise. If you'd actually prefer Clear All to wipe stats too, that's a product decision — say the word and I'll update both the method and the dialog copy in a follow-up.

## Test plan
- Record a few transcriptions (creates audio files) → Clear All → audio files are gone from Application Support; stats history remains.