### PR TITLE
feat: configurable recorder pill position

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on Keep a Changelog, and this project adheres to Semantic Versioning.
 
 ## [Unreleased]
-- 
+- Recorder pill position: new setting under General lets the user pin the floating recorder to any of the 9 on-screen positions (4 corners, 3 mid-edges, top/bottom center). Default is bottom center.
 
 ## [1.3.0] - 2026-07-10
 - 

--- a/speaktype/App/AppDelegate.swift
+++ b/speaktype/App/AppDelegate.swift
@@ -30,6 +30,28 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             self?.miniRecorderController?.applyIdleVisibilityPreference()
         }
 
+        // React to the "recorder pill position" change at runtime. The
+        // controller defers the actual move while a recording is in progress
+        // so the HUD doesn't jump under the user's cursor.
+        NotificationCenter.default.addObserver(
+            forName: .recorderPillPositionChanged,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            self?.miniRecorderController?.applyPillPosition()
+        }
+
+        // Reposition the pill when displays change (external monitor
+        // connected/disconnected, dock resized, etc.) so it doesn't end up
+        // off-screen relative to the new layout.
+        NotificationCenter.default.addObserver(
+            forName: NSApplication.didChangeScreenParametersNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            self?.miniRecorderController?.handleScreenParametersChanged()
+        }
+
         // Only show the Dock icon while the dashboard is actually open; otherwise
         // live quietly in the menu bar.
         observeWindowsForDockIcon()

--- a/speaktype/Constants/Shortcuts+Extensions.swift
+++ b/speaktype/Constants/Shortcuts+Extensions.swift
@@ -14,4 +14,7 @@ extension Notification.Name {
     /// Posted when the "always show recorder pill" preference changes so the
     /// window controller can show/hide the idle pill immediately.
     static let recorderIdleVisibilityChanged = Notification.Name("recorderIdleVisibilityChanged")
+    /// Posted when the user picks a new "recorder pill position" in Settings so
+    /// the window controller can move the pill without touching visibility.
+    static let recorderPillPositionChanged = Notification.Name("recorderPillPositionChanged")
 }

--- a/speaktype/Controllers/MiniRecorderWindowController.swift
+++ b/speaktype/Controllers/MiniRecorderWindowController.swift
@@ -15,6 +15,17 @@ class MiniRecorderWindowController: NSObject {
         UserDefaults.standard.bool(forKey: "alwaysShowRecorderPill")
     }
 
+    /// Where the pill sits on screen. Read from UserDefaults each time it is
+    /// repositioned, so the latest value is always used.
+    private var pillPosition: PillPosition {
+        if let raw = UserDefaults.standard.string(forKey: PillPosition.defaultsKey),
+            let pos = PillPosition(rawValue: raw)
+        {
+            return pos
+        }
+        return .defaultPosition
+    }
+
     /// Prepare the resting pill. Called once at launch. When "always show" is on
     /// the pill lives on screen and morphs into the recording HUD; when off it
     /// stays hidden until recording starts.
@@ -24,7 +35,7 @@ class MiniRecorderWindowController: NSObject {
         }
         guard let panel = panel else { return }
 
-        centerPanel()
+        positionPanel()
         // Idle pill is a passive indicator — let clicks pass through to whatever is
         // behind it so the transparent window never blocks the desktop or dock.
         panel.ignoresMouseEvents = true
@@ -42,7 +53,7 @@ class MiniRecorderWindowController: NSObject {
         guard let panel = panel else { return }
 
         if alwaysShowIdlePill {
-            centerPanel()
+            positionPanel()
             panel.ignoresMouseEvents = true
             if !panel.isVisible {
                 panel.orderFrontRegardless()
@@ -52,6 +63,30 @@ class MiniRecorderWindowController: NSObject {
             // interactive (ignoresMouseEvents == false), so leave it alone.
             panel.orderOut(nil)
         }
+    }
+
+    /// React to the "recorder pill position" preference changing at runtime.
+    /// Defer the move while a recording is in progress so the HUD doesn't
+    /// teleport under the user's cursor; the next `startRecording()` /
+    /// `showIdleRecorder()` will place it in the new spot.
+    func applyPillPosition() {
+        if panel == nil {
+            setupPanel()
+        }
+        guard let panel = panel else { return }
+        guard !AudioRecordingService.shared.isRecording else { return }
+        guard panel.isVisible else { return }
+        positionPanel()
+    }
+
+    /// Reposition the pill when the display configuration changes (external
+    /// monitor connected/disconnected, dock resized, etc.) so it doesn't end
+    /// up off-screen relative to the new layout. Deferred mid-recording so the
+    /// HUD doesn't jump under the user's cursor; the next `startRecording()`
+    /// / `showIdleRecorder()` will place it in the new spot.
+    func handleScreenParametersChanged() {
+        guard !AudioRecordingService.shared.isRecording else { return }
+        positionPanel()
     }
 
     // Start recording - show panel and begin recording
@@ -65,7 +100,7 @@ class MiniRecorderWindowController: NSObject {
 
         guard let panel = panel else { return }
 
-        centerPanel()
+        positionPanel()
         // Become interactive so the recording HUD (stop dot, hover controls) works.
         panel.ignoresMouseEvents = false
 
@@ -78,20 +113,24 @@ class MiniRecorderWindowController: NSObject {
         NotificationCenter.default.post(name: .recordingStartRequested, object: nil)
     }
 
-    /// Center the panel horizontally on its current screen, floating just above
-    /// the dock. Safe to call repeatedly (on show and on every resize).
-    private func centerPanel() {
+    /// Position the panel on its current screen according to the user's chosen
+    /// `PillPosition`. Safe to call repeatedly (on show and on every resize).
+    private func positionPanel() {
         guard let panel = panel else { return }
         let screen = panel.screen ?? NSScreen.main
         guard let visibleFrame = screen?.visibleFrame else {
             panel.center()
             return
         }
-        let x = visibleFrame.midX - (panel.frame.width / 2)
-        let y = visibleFrame.minY + 4  // sit low & discreet, just above the dock
-        let origin = NSPoint(x: (x).rounded(), y: (y).rounded())
-        if panel.frame.origin != origin {
-            panel.setFrameOrigin(origin)
+
+        let origin = PillPosition.origin(
+            for: pillPosition,
+            panelSize: panel.frame.size,
+            visibleFrame: visibleFrame
+        )
+        let rounded = NSPoint(x: origin.x.rounded(), y: origin.y.rounded())
+        if panel.frame.origin != rounded {
+            panel.setFrameOrigin(rounded)
         }
     }
 
@@ -102,6 +141,9 @@ class MiniRecorderWindowController: NSObject {
         panel.ignoresMouseEvents = true
         if !alwaysShowIdlePill {
             panel.orderOut(nil)
+        } else {
+            // Pick up any position change that was deferred mid-recording.
+            positionPanel()
         }
     }
 
@@ -165,7 +207,7 @@ class MiniRecorderWindowController: NSObject {
         p.maxSize = fixedSize
         p.titleVisibility = .hidden
         p.titlebarAppearsTransparent = true
-        p.isMovableByWindowBackground = false  // stay put — always screen-centered
+        p.isMovableByWindowBackground = false  // stay put — positioned by positionPanel() per user preference
         p.hasShadow = false  // Disable system shadow to avoid transparency artifacts (View has its own shadow)
 
         // Window Behavior

--- a/speaktype/Models/PillPosition.swift
+++ b/speaktype/Models/PillPosition.swift
@@ -1,0 +1,61 @@
+import AppKit
+import Foundation
+
+/// Where the floating recorder pill sits on screen.
+enum PillPosition: String, Codable, CaseIterable, Identifiable {
+    case topLeft, topCenter, topRight
+    case centerLeft, center, centerRight
+    case bottomLeft, bottomCenter, bottomRight
+
+    var id: String { rawValue }
+
+    /// UserDefaults key backing the user's chosen position.
+    static let defaultsKey = "recorderPillPosition"
+
+    /// The position used when the key is missing or invalid.
+    static let defaultPosition: PillPosition = .bottomCenter
+
+    var displayName: String {
+        switch self {
+        case .topLeft:      return "Top Left"
+        case .topCenter:    return "Top Center"
+        case .topRight:     return "Top Right"
+        case .centerLeft:   return "Middle Left"
+        case .center:       return "Center"
+        case .centerRight:  return "Middle Right"
+        case .bottomLeft:   return "Bottom Left"
+        case .bottomCenter: return "Bottom Center"
+        case .bottomRight:  return "Bottom Right"
+        }
+    }
+
+    /// Pure geometry: where the panel's top-left should land for a given
+    /// position, panel size, and screen-visible frame. Inset from all four
+    /// screen edges by `edgeInset` so the pill never sits flush with the
+    /// menu bar or dock.
+    static func origin(
+        for position: PillPosition,
+        panelSize: NSSize,
+        visibleFrame: NSRect,
+        edgeInset: CGFloat = 8
+    ) -> NSPoint {
+        let midY = visibleFrame.midY - panelSize.height / 2
+        let topY = visibleFrame.maxY - panelSize.height - edgeInset
+        let bottomY = visibleFrame.minY + edgeInset
+        let leftX = visibleFrame.minX + edgeInset
+        let rightX = visibleFrame.maxX - panelSize.width - edgeInset
+        let centerX = visibleFrame.midX - panelSize.width / 2
+
+        switch position {
+        case .topLeft:      return NSPoint(x: leftX,    y: topY)
+        case .topCenter:    return NSPoint(x: centerX,  y: topY)
+        case .topRight:     return NSPoint(x: rightX,   y: topY)
+        case .centerLeft:   return NSPoint(x: leftX,    y: midY)
+        case .center:       return NSPoint(x: centerX,  y: midY)
+        case .centerRight:  return NSPoint(x: rightX,   y: midY)
+        case .bottomLeft:   return NSPoint(x: leftX,    y: bottomY)
+        case .bottomCenter: return NSPoint(x: centerX,  y: bottomY)
+        case .bottomRight:  return NSPoint(x: rightX,   y: bottomY)
+        }
+    }
+}

--- a/speaktype/Views/Screens/Settings/SettingsView.swift
+++ b/speaktype/Views/Screens/Settings/SettingsView.swift
@@ -93,6 +93,7 @@ struct GeneralSettingsTab: View {
         true
     @AppStorage("showMenuBarIcon") private var showMenuBarIcon: Bool = true
     @AppStorage("alwaysShowRecorderPill") private var alwaysShowRecorderPill: Bool = false
+    @AppStorage(PillPosition.defaultsKey) private var recorderPillPosition: PillPosition = .defaultPosition
     @AppStorage("transcriptionLanguage") private var transcriptionLanguage: String = "auto"
     @AppStorage("recentTranscriptionLanguages") private var recentLanguagesString: String = ""
     @AppStorage("enableAutoEdit") private var enableAutoEdit: Bool = false
@@ -249,6 +250,44 @@ struct GeneralSettingsTab: View {
                                 alwaysShowRecorderPill
                                     ? "The small floating recorder stays on screen even when you're not dictating."
                                     : "The floating recorder appears only while you're dictating and hides when idle."
+                            )
+                            .font(Typography.captionSmall)
+                            .foregroundStyle(Color.textMuted)
+                        }
+
+                        VStack(alignment: .leading, spacing: 6) {
+                            HStack {
+                                Text("Recorder pill position")
+                                    .font(Typography.bodyMedium)
+                                    .foregroundStyle(Color.textPrimary)
+                                Spacer()
+                                Menu {
+                                    ForEach(PillPosition.allCases) { pos in
+                                        Button(pos.displayName) {
+                                            recorderPillPosition = pos
+                                            NotificationCenter.default.post(
+                                                name: .recorderPillPositionChanged, object: nil)
+                                        }
+                                    }
+                                } label: {
+                                    HStack(spacing: 6) {
+                                        Text(recorderPillPosition.displayName)
+                                            .font(Typography.bodySmall)
+                                            .foregroundStyle(Color.textPrimary)
+                                        Image(systemName: "chevron.up.chevron.down")
+                                            .font(.system(size: 9))
+                                            .foregroundStyle(Color.textPrimary)
+                                    }
+                                    .padding(.horizontal, 12)
+                                    .padding(.vertical, 7)
+                                    .background(Color.bgHover)
+                                    .clipShape(RoundedRectangle(cornerRadius: 6))
+                                }
+                                .menuStyle(.borderlessButton)
+                            }
+
+                            Text(
+                                "Where the floating recorder appears on screen. Visible while dictating, or always if “Always show recorder pill” is on."
                             )
                             .font(Typography.captionSmall)
                             .foregroundStyle(Color.textMuted)

--- a/speaktypeTests/PillPositionTests.swift
+++ b/speaktypeTests/PillPositionTests.swift
@@ -1,0 +1,125 @@
+import XCTest
+import Cocoa
+@testable import speaktype
+
+final class PillPositionTests: XCTestCase {
+    // 1440x900 with a 25px menu bar and 70px dock, leaving visibleFrame
+    // (0, 70, 1440, 805). Matches what AppKit reports for a typical
+    // MacBook display with the dock pinned to the bottom.
+    private let visibleFrame = NSRect(x: 0, y: 70, width: 1440, height: 805)
+    private let panelSize = NSSize(width: 520, height: 84)
+    private let edgeInset: CGFloat = 8
+
+    func testTopRight_landsInTopRightCorner() {
+        let origin = PillPosition.origin(
+            for: .topRight,
+            panelSize: panelSize,
+            visibleFrame: visibleFrame,
+            edgeInset: edgeInset
+        )
+        XCTAssertEqual(origin.x, visibleFrame.maxX - panelSize.width - edgeInset)
+        XCTAssertEqual(origin.y, visibleFrame.maxY - panelSize.height - edgeInset)
+    }
+
+    func testTopLeft_landsInTopLeftCorner() {
+        let origin = PillPosition.origin(
+            for: .topLeft,
+            panelSize: panelSize,
+            visibleFrame: visibleFrame,
+            edgeInset: edgeInset
+        )
+        XCTAssertEqual(origin.x, visibleFrame.minX + edgeInset)
+        XCTAssertEqual(origin.y, visibleFrame.maxY - panelSize.height - edgeInset)
+    }
+
+    func testBottomCenter_isHorizontallyCentered() {
+        let origin = PillPosition.origin(
+            for: .bottomCenter,
+            panelSize: panelSize,
+            visibleFrame: visibleFrame,
+            edgeInset: edgeInset
+        )
+        XCTAssertEqual(origin.x, visibleFrame.midX - panelSize.width / 2)
+        XCTAssertEqual(origin.y, visibleFrame.minY + edgeInset)
+    }
+
+    func testBottomRight_usesRightEdge() {
+        let origin = PillPosition.origin(
+            for: .bottomRight,
+            panelSize: panelSize,
+            visibleFrame: visibleFrame,
+            edgeInset: edgeInset
+        )
+        XCTAssertEqual(origin.x, visibleFrame.maxX - panelSize.width - edgeInset)
+        XCTAssertEqual(origin.y, visibleFrame.minY + edgeInset)
+    }
+
+    func testCenter_isScreenCentered() {
+        let origin = PillPosition.origin(
+            for: .center,
+            panelSize: panelSize,
+            visibleFrame: visibleFrame,
+            edgeInset: edgeInset
+        )
+        XCTAssertEqual(origin.x, visibleFrame.midX - panelSize.width / 2)
+        XCTAssertEqual(origin.y, visibleFrame.midY - panelSize.height / 2)
+    }
+
+    func testCenterRight_sitsAtVerticalCenterOnRightEdge() {
+        let origin = PillPosition.origin(
+            for: .centerRight,
+            panelSize: panelSize,
+            visibleFrame: visibleFrame,
+            edgeInset: edgeInset
+        )
+        XCTAssertEqual(origin.x, visibleFrame.maxX - panelSize.width - edgeInset)
+        XCTAssertEqual(origin.y, visibleFrame.midY - panelSize.height / 2)
+    }
+
+    func testTopCenter_isHorizontallyCenteredAtTop() {
+        let origin = PillPosition.origin(
+            for: .topCenter,
+            panelSize: panelSize,
+            visibleFrame: visibleFrame,
+            edgeInset: edgeInset
+        )
+        XCTAssertEqual(origin.x, visibleFrame.midX - panelSize.width / 2)
+        XCTAssertEqual(origin.y, visibleFrame.maxY - panelSize.height - edgeInset)
+    }
+
+    func testCenterLeft_sitsAtVerticalCenterOnLeftEdge() {
+        let origin = PillPosition.origin(
+            for: .centerLeft,
+            panelSize: panelSize,
+            visibleFrame: visibleFrame,
+            edgeInset: edgeInset
+        )
+        XCTAssertEqual(origin.x, visibleFrame.minX + edgeInset)
+        XCTAssertEqual(origin.y, visibleFrame.midY - panelSize.height / 2)
+    }
+
+    func testBottomLeft_landsInBottomLeftCorner() {
+        let origin = PillPosition.origin(
+            for: .bottomLeft,
+            panelSize: panelSize,
+            visibleFrame: visibleFrame,
+            edgeInset: edgeInset
+        )
+        XCTAssertEqual(origin.x, visibleFrame.minX + edgeInset)
+        XCTAssertEqual(origin.y, visibleFrame.minY + edgeInset)
+    }
+
+    func testDefaultPosition_isBottomCenter() {
+        XCTAssertEqual(PillPosition.defaultPosition, .bottomCenter)
+    }
+
+    func testDefaultsKey_isStable() {
+        // If this changes, any installed user's saved preference is lost.
+        XCTAssertEqual(PillPosition.defaultsKey, "recorderPillPosition")
+    }
+
+    func testAllCases_haveUniqueRawValues() {
+        let raws = PillPosition.allCases.map(\.rawValue)
+        XCTAssertEqual(Set(raws).count, raws.count)
+    }
+}


### PR DESCRIPTION
Mainly because the Recorder 'pill' is sitting in the way of a lot of text input boxes I use daily.

Add a 'Recorder pill position' setting under General so the floating recorder can be pinned to any of the 9 on-screen positions (4 corners, 3 mid-edges, top/bottom center). Default stays at bottom center so existing behaviour is unchanged.

The pill is repositioned live when the setting changes, on display configuration changes, and when a recording settles to idle. Mid-recording position changes are deferred so the HUD doesn't jump under the user's cursor.

Introduce `PillPosition` (Models/) with a pure origin(`for:panelSize: visibleFrame:edgeInset:`) helper, covered by unit tests for all 9 grid cells.

<img width="585" height="328" alt="image" src="https://github.com/user-attachments/assets/ea0b7eda-4f81-4806-967f-6ec83320bc80" />


_Note: I am not a swift engineer by trade and I got AI to help me write this but ran it through multiple adversarial review cycles and have reviewed the code myself_