### PR TITLE
fix: surface model download progress and failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on Keep a Changelog, and this project adheres to Semantic Versioning.
 
 ## [Unreleased]
-- Smart trailing punctuation: when a dictation is just an email address, URL, number, or single word, the sentence-final period the model adds is stripped so the text pastes clean. Default-on toggle in Settings → General → Transcript Cleanup.
-- Recorder pill position: new setting under General lets the user pin the floating recorder to any of the 9 on-screen positions (4 corners, 3 mid-edges, top/bottom center). Default is bottom center.
+- 
 
 ## [1.3.0] - 2026-07-10
 - 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on Keep a Changelog, and this project adheres to Semantic Versioning.
 
 ## [Unreleased]
-- 
+- Fix: the recommended model on the AI Models screen now shows download progress, a cancel button, and the actual reason a download failed (with a retry) instead of a Download button that appeared to do nothing.
+- Fix: a half-finished Parakeet download is no longer reported as installed.
 
 ## [1.3.0] - 2026-07-10
 - 

--- a/speaktype/Services/ModelDownloadService.swift
+++ b/speaktype/Services/ModelDownloadService.swift
@@ -131,6 +131,63 @@ class ModelDownloadService: ObservableObject {
         }
     }
     
+    /// Merges a fresh disk scan with the downloads that are still running.
+    ///
+    /// The AI Models screen refreshes on every appearance, so a refresh must not
+    /// clobber an in-flight download's fraction (which would reset the progress
+    /// bar to 0% and make a running download look stalled), and must not mark a
+    /// model still being fetched as installed. Pure, so it can be tested.
+    static func mergedProgress(
+        foundOnDisk: Set<String>,
+        inFlight: [String: Bool],
+        currentProgress: [String: Double]
+    ) -> [String: Double] {
+        var merged: [String: Double] = [:]
+        for variant in foundOnDisk {
+            merged[variant] = 1.0
+        }
+        for (variant, downloading) in inFlight where downloading {
+            // A download in flight is never "installed" yet — the task itself
+            // writes 1.0 when it finishes.
+            merged[variant] = min(currentProgress[variant] ?? 0.0, 0.99)
+        }
+        return merged
+    }
+
+    /// Turns a download failure into something a user can act on.
+    ///
+    /// The raw `localizedDescription` of a URLSession/Hugging Face failure is
+    /// often opaque ("The request timed out"), and the UI previously swallowed it
+    /// entirely — a failed download just silently returned to a "Download"
+    /// button with no explanation.
+    static func userFacingMessage(for error: Error) -> String {
+        let nsError = error as NSError
+
+        if nsError.domain == NSURLErrorDomain {
+            switch nsError.code {
+            case NSURLErrorNotConnectedToInternet, NSURLErrorCannotFindHost,
+                 NSURLErrorCannotConnectToHost, NSURLErrorNetworkConnectionLost,
+                 NSURLErrorDNSLookupFailed:
+                return "Couldn't reach Hugging Face. Check your internet connection and try again."
+            case NSURLErrorTimedOut:
+                return "The download timed out. Check your connection and try again — finished parts are kept."
+            default:
+                break
+            }
+        }
+
+        if nsError.domain == NSCocoaErrorDomain, nsError.code == NSFileWriteOutOfSpaceError {
+            return "Not enough free disk space to finish this download."
+        }
+
+        let description = error.localizedDescription
+        if description.localizedCaseInsensitiveContains("rate limit") || description.contains("429") {
+            return "Hugging Face is rate-limiting downloads right now. Wait a minute, then try again."
+        }
+
+        return "Download failed: \(description)"
+    }
+
     // Check which models are already downloaded and update progress dictionary
     func refreshDownloadedModels() async {
         print("🔍 Checking for already-downloaded models...")
@@ -140,8 +197,6 @@ class ModelDownloadService: ObservableObject {
         // NOTE: WhisperKit.fetchAvailableModels() returns ALL remote models, not local ones
         // We ONLY rely on disk-based verification to check what's actually downloaded
         
-        let fileManager = FileManager.default
-
         // Verify models actually exist on disk with proper size validation.
         // Scan the current Application Support location plus the legacy Documents
         // location (in case a migration move failed or hasn't run yet).
@@ -155,21 +210,28 @@ class ModelDownloadService: ObservableObject {
         for variant in ParakeetCatalog.variants {
             let version = ParakeetCatalog.version(for: variant)
             let cacheDir = AsrModels.defaultCacheDirectory(for: version)
-            if fileManager.fileExists(atPath: cacheDir.path),
-               let contents = try? fileManager.contentsOfDirectory(atPath: cacheDir.path),
-               !contents.isEmpty {
+            // A non-empty cache directory is NOT proof of a usable model: an
+            // interrupted or failed download leaves some of the .mlmodelc bundles
+            // behind, and treating that as "installed" hides the Download button
+            // for a model that can never load. Ask FluidAudio whether every file
+            // this version requires is actually present.
+            if AsrModels.modelsExist(at: cacheDir, version: version) {
                 foundModels.insert(variant)
                 print("✅ Parakeet model \(variant) found in cache")
+            } else if FileManager.default.fileExists(atPath: cacheDir.path) {
+                print("⚠️ Parakeet model \(variant) is incomplete at \(cacheDir.path)")
             }
         }
 
         await MainActor.run {
-            // Clear all previous progress
-            self.downloadProgress.removeAll()
-
-            // Only mark models that actually exist
+            // Rebuild in one assignment so the UI never flickers through an empty
+            // state, and never drop a download that is still running.
+            self.downloadProgress = Self.mergedProgress(
+                foundOnDisk: foundModels,
+                inFlight: self.isDownloading,
+                currentProgress: self.downloadProgress
+            )
             for variant in foundModels {
-                self.downloadProgress[variant] = 1.0
                 print("✅ Marked as downloaded: \(variant)")
             }
             
@@ -338,7 +400,7 @@ class ModelDownloadService: ObservableObject {
                          DispatchQueue.main.async {
                              self.isDownloading[variant] = false
                              self.downloadProgress[variant] = 0.0
-                             self.downloadError[variant] = "Error: \(error.localizedDescription)\n\nTry clicking the trash icon to manually clean cache."
+                             self.downloadError[variant] = Self.userFacingMessage(for: error)
                              self.activeTasks[variant] = nil
                          }
                      }
@@ -348,7 +410,7 @@ class ModelDownloadService: ObservableObject {
                 DispatchQueue.main.async {
                     self.isDownloading[variant] = false
                     self.downloadProgress[variant] = 0.0
-                    self.downloadError[variant] = error.localizedDescription + "\n\n(Try Trash icon to clean cache)"
+                    self.downloadError[variant] = Self.userFacingMessage(for: error)
                     self.activeTasks[variant] = nil
                 }
             }
@@ -393,7 +455,7 @@ class ModelDownloadService: ObservableObject {
                 DispatchQueue.main.async {
                     self.isDownloading[variant] = false
                     self.downloadProgress[variant] = 0.0
-                    self.downloadError[variant] = error.localizedDescription
+                    self.downloadError[variant] = Self.userFacingMessage(for: error)
                     self.activeTasks[variant] = nil
                 }
             }

--- a/speaktype/Views/Components/ModelRow.swift
+++ b/speaktype/Views/Components/ModelRow.swift
@@ -24,6 +24,7 @@ struct ModelRow: View {
     var progress: Double { downloadService.downloadProgress[model.variant] ?? 0.0 }
     var isDownloading: Bool { downloadService.isDownloading[model.variant] ?? false }
     var isDownloaded: Bool { progress >= 1.0 }
+    var downloadError: String? { downloadService.downloadError[model.variant] }
     var isActive: Bool { selectedModel == model.variant }
 
     // MARK: - Body
@@ -41,6 +42,11 @@ struct ModelRow: View {
 
                     if let warning = model.ramWarning(deviceRAMGB: WhisperService.deviceRAMGB) {
                         note(icon: "exclamationmark.triangle.fill", text: warning, tint: .accentWarning)
+                    }
+                    // A failed download used to leave no trace at all — the button
+                    // just flipped back to "Download" with no explanation.
+                    if let downloadError, !isDownloading {
+                        note(icon: "exclamationmark.triangle.fill", text: downloadError, tint: .accentError)
                     }
                     if let loadError {
                         note(icon: "xmark.circle.fill", text: loadError, tint: .accentError)
@@ -123,7 +129,8 @@ struct ModelRow: View {
     private func note(icon: String, text: String, tint: Color) -> some View {
         HStack(spacing: 5) {
             Image(systemName: icon).font(.system(size: 10))
-            Text(text).font(Typography.ui(11)).lineLimit(2)
+            Text(text).font(Typography.ui(11)).lineLimit(3)
+                .fixedSize(horizontal: false, vertical: true)
         }
         .foregroundStyle(tint)
     }
@@ -158,7 +165,10 @@ struct ModelRow: View {
                 .buttonStyle(.plain)
             } else {
                 Button(action: { downloadService.downloadModel(variant: model.variant) }) {
-                    ActionButton.label(title: "Download", icon: "arrow.down", style: .primary)
+                    ActionButton.label(
+                        title: downloadError == nil ? "Download" : "Try again",
+                        icon: downloadError == nil ? "arrow.down" : "arrow.clockwise",
+                        style: .primary)
                 }
                 .buttonStyle(.plain)
             }

--- a/speaktype/Views/Screens/Settings/AIModelsView.swift
+++ b/speaktype/Views/Screens/Settings/AIModelsView.swift
@@ -188,30 +188,94 @@ struct AIModelsView: View {
         .shadow(color: Color.brandAccent.opacity(0.10), radius: 20, x: 0, y: 8)
     }
 
-    @ViewBuilder
+    /// The hero is the *only* place the recommended model can be downloaded from
+    /// — it is deliberately filtered out of the list below — so it has to carry
+    /// the full download state machine (progress, cancel, failure, retry). It
+    /// previously showed a bare "Download" button in every state, so a download
+    /// that was running (or had failed) looked like a button that did nothing.
     private func heroAction(rec: AIModel, downloaded: Bool, active: Bool) -> some View {
-        if active && downloaded {
-            HStack(spacing: 7) {
-                Image(systemName: "checkmark.circle.fill")
-                Text("This is your default model").font(Typography.uiBold(13))
+        let downloading = downloadService.isDownloading[rec.variant] ?? false
+        let error = downloadService.downloadError[rec.variant]
+
+        return VStack(alignment: .leading, spacing: 12) {
+            if downloading {
+                heroDownloadProgress(variant: rec.variant)
+            } else if active && downloaded {
+                HStack(spacing: 7) {
+                    Image(systemName: "checkmark.circle.fill")
+                    Text("This is your default model").font(Typography.uiBold(13))
+                }
+                .foregroundStyle(Color.brandAccent)
+            } else if downloaded {
+                Button {
+                    selectedModel = rec.variant
+                } label: {
+                    ActionButton.label(title: "Use this model", icon: "arrow.right",
+                                       style: .primary, large: true)
+                }
+                .buttonStyle(.plain)
+            } else {
+                if let error {
+                    HStack(alignment: .top, spacing: 6) {
+                        Image(systemName: "exclamationmark.triangle.fill")
+                            .font(.system(size: 11))
+                        Text(error)
+                            .font(Typography.ui(12))
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                    .foregroundStyle(Color.accentError)
+                    .frame(maxWidth: 420, alignment: .leading)
+                }
+
+                Button {
+                    downloadService.downloadModel(variant: rec.variant)
+                } label: {
+                    ActionButton.label(title: error == nil ? "Download" : "Try again",
+                                       icon: error == nil ? "arrow.down" : "arrow.clockwise",
+                                       style: .primary, large: true)
+                }
+                .buttonStyle(.plain)
             }
-            .foregroundStyle(Color.brandAccent)
-        } else if downloaded {
-            Button {
-                selectedModel = rec.variant
-            } label: {
-                ActionButton.label(title: "Use this model", icon: "arrow.right",
-                                   style: .primary, large: true)
+        }
+    }
+
+    /// Live progress for the hero's download, with a way out of it.
+    private func heroDownloadProgress(variant: String) -> some View {
+        let progress = downloadService.downloadProgress[variant] ?? 0.0
+        return VStack(alignment: .leading, spacing: 10) {
+            HStack(spacing: 9) {
+                Spinner(size: 13, lineWidth: 2, tint: Color.brandAccent)
+                Text("Downloading…")
+                    .font(Typography.uiMedium(13))
+                    .foregroundStyle(Color.textSecondary)
+                Text("\(Int(progress * 100))%")
+                    .font(Typography.uiBold(13))
+                    .foregroundStyle(Color.brandAccent)
+                    .monospacedDigit()
             }
-            .buttonStyle(.plain)
-        } else {
-            Button {
-                downloadService.downloadModel(variant: rec.variant)
-            } label: {
-                ActionButton.label(title: "Download", icon: "arrow.down",
-                                   style: .primary, large: true)
+
+            GeometryReader { geo in
+                ZStack(alignment: .leading) {
+                    Capsule().fill(Color.textPrimary.opacity(0.08)).frame(height: 6)
+                    Capsule().fill(Color.brandAccent)
+                        .frame(width: max(6, geo.size.width * progress), height: 6)
+                        .animation(.easeOut(duration: 0.2), value: progress)
+                }
             }
-            .buttonStyle(.plain)
+            .frame(width: 320, height: 6)
+
+            HStack(spacing: 12) {
+                Button {
+                    downloadService.cancelDownload(for: variant)
+                } label: {
+                    ActionButton.label(title: "Cancel", icon: "xmark", style: .secondary)
+                }
+                .buttonStyle(.plain)
+
+                Text("Large models take a few minutes on a first download.")
+                    .font(Typography.ui(11))
+                    .foregroundStyle(Color.textMuted)
+            }
         }
     }
 

--- a/speaktypeTests/ModelDownloadServiceTests.swift
+++ b/speaktypeTests/ModelDownloadServiceTests.swift
@@ -105,6 +105,91 @@ final class ModelDownloadServiceTests: XCTestCase {
         XCTAssertTrue(FileManager.default.fileExists(atPath: unrelatedPath.path))
     }
 
+    // MARK: - Refresh vs. in-flight downloads
+
+    func testMergedProgressMarksModelsFoundOnDiskAsInstalled() {
+        let merged = ModelDownloadService.mergedProgress(
+            foundOnDisk: ["parakeet-tdt-0.6b-v2"],
+            inFlight: [:],
+            currentProgress: [:]
+        )
+
+        XCTAssertEqual(merged["parakeet-tdt-0.6b-v2"], 1.0)
+    }
+
+    func testMergedProgressKeepsInFlightDownloadFraction() {
+        // The AI Models screen refreshes on every appearance; that must not reset a
+        // running download's progress bar to 0%.
+        let merged = ModelDownloadService.mergedProgress(
+            foundOnDisk: [],
+            inFlight: ["parakeet-tdt-0.6b-v2": true],
+            currentProgress: ["parakeet-tdt-0.6b-v2": 0.42]
+        )
+
+        XCTAssertEqual(merged["parakeet-tdt-0.6b-v2"], 0.42)
+    }
+
+    func testMergedProgressNeverMarksAnInFlightDownloadAsInstalled() {
+        // A half-written cache directory must not flip the UI to "Installed" —
+        // that hides the download and leaves the user with a model that can't load.
+        let merged = ModelDownloadService.mergedProgress(
+            foundOnDisk: ["parakeet-tdt-0.6b-v2"],
+            inFlight: ["parakeet-tdt-0.6b-v2": true],
+            currentProgress: ["parakeet-tdt-0.6b-v2": 0.9]
+        )
+
+        XCTAssertEqual(merged["parakeet-tdt-0.6b-v2"], 0.9)
+        XCTAssertLessThan(merged["parakeet-tdt-0.6b-v2"] ?? 1.0, 1.0)
+    }
+
+    func testMergedProgressDropsModelsThatAreNoLongerOnDisk() {
+        let merged = ModelDownloadService.mergedProgress(
+            foundOnDisk: [],
+            inFlight: ["openai_whisper-tiny": false],
+            currentProgress: ["openai_whisper-tiny": 1.0]
+        )
+
+        XCTAssertNil(merged["openai_whisper-tiny"])
+    }
+
+    // MARK: - Failure messages
+
+    func testUserFacingMessageExplainsOfflineFailures() {
+        let error = NSError(domain: NSURLErrorDomain, code: NSURLErrorNotConnectedToInternet)
+
+        let message = ModelDownloadService.userFacingMessage(for: error)
+
+        XCTAssertTrue(message.contains("internet connection"), message)
+    }
+
+    func testUserFacingMessageExplainsRateLimiting() {
+        let error = NSError(
+            domain: "HuggingFace", code: 429,
+            userInfo: [NSLocalizedDescriptionKey: "Hugging Face rate limit encountered: slow down"])
+
+        let message = ModelDownloadService.userFacingMessage(for: error)
+
+        XCTAssertTrue(message.localizedCaseInsensitiveContains("rate-limiting"), message)
+    }
+
+    func testUserFacingMessageExplainsOutOfDiskSpace() {
+        let error = NSError(domain: NSCocoaErrorDomain, code: NSFileWriteOutOfSpaceError)
+
+        let message = ModelDownloadService.userFacingMessage(for: error)
+
+        XCTAssertTrue(message.localizedCaseInsensitiveContains("disk space"), message)
+    }
+
+    func testUserFacingMessageFallsBackToTheUnderlyingDescription() {
+        let error = NSError(
+            domain: "Test", code: 1,
+            userInfo: [NSLocalizedDescriptionKey: "Something specific broke"])
+
+        let message = ModelDownloadService.userFacingMessage(for: error)
+
+        XCTAssertTrue(message.contains("Something specific broke"), message)
+    }
+
     @discardableResult
     private func createDirectory(at url: URL) throws -> URL {
         try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)


### PR DESCRIPTION
## The bug

A user on a fresh install reported being **unable to download the model recommended to them**.

The `RECOMMENDED FOR YOU` hero is the *only* place the recommended model can be downloaded — `AIModelsView.swift` deliberately filters it out of the list below to avoid duplication. But `heroAction` only handled three states (*installed+active*, *installed*, *everything else → a plain "Download" button*), so:

- **While downloading**, the hero still showed "Download". A ~2 GB Parakeet download gave zero feedback for minutes, and a second click hits the `guard isDownloading[variant] != true` in `ModelDownloadService` and silently no-ops.
- **On failure**, it silently reverted to "Download". `downloadError` was written by the service but read by **no view in the app** — a Hugging Face rate limit, a dropped connection, or a full disk was completely invisible.

A third defect compounded it: Parakeet install detection was "cache dir exists and is non-empty", so a half-finished download reported as **installed** — the Download button disappeared for a model that could never load.

## The fix

- **`AIModelsView`** — hero carries the full state machine: live progress bar + percentage + spinner, a Cancel button, and on failure the actual reason with a "Try again" button.
- **`ModelRow`** — download failures render as an error note on the card; the button reads "Try again".
- **`ModelDownloadService`**
  - Parakeet detection now asks FluidAudio `AsrModels.modelsExist(at:version:)` whether every required file is present.
  - New `userFacingMessage(for:)` maps failures to actionable text (no connection / timed out / HF rate-limiting / out of disk space).
  - `refreshDownloadedModels()` no longer does `downloadProgress.removeAll()` — the screen refreshes on every appearance, which reset an in-flight download's bar to 0%. New pure `mergedProgress(...)` rebuilds the map in one assignment and preserves running downloads.

## Testing

8 new unit tests in `ModelDownloadServiceTests` covering the two new pure helpers (progress merge vs. in-flight downloads, and the failure-message mapping).

Note: this was authored on a machine without Xcode, so local `xcodebuild` could not run — all files pass `swiftc -parse` and **CI is the build/test gate here**.

Caveat on expectations: if the original download was failing for an environmental reason (HF rate limit, flaky network, disk space), this does not make it succeed — it makes the reason visible and offers a retry that resumes from files already fetched.