### PR TITLE
fix: warm models up after download instead of mid-dictation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on Keep a Changelog, and this project adheres to Semantic Versioning.
 
 ## [Unreleased]
+- Models are now warmed up as soon as they finish downloading (and when you pick one), so the first dictation no longer stalls on "warming up".
+- Fix: the recorder's warming-up message was clipped mid-word, and pressing esc left it wedged on screen. It now shows the real loading stage, elapsed time, and settles back to idle.
 - Fix: the recommended model on the AI Models screen now shows download progress, a cancel button, and the actual reason a download failed (with a retry) instead of a Download button that appeared to do nothing.
 - Fix: a half-finished Parakeet download is no longer reported as installed.
 

--- a/speaktype/Services/ModelDownloadService.swift
+++ b/speaktype/Services/ModelDownloadService.swift
@@ -131,6 +131,31 @@ class ModelDownloadService: ObservableObject {
         }
     }
     
+    /// True when this variant is fully downloaded and ready to load.
+    func isDownloaded(_ variant: String) -> Bool {
+        (downloadProgress[variant] ?? 0) >= 1.0
+    }
+
+    /// Gets a freshly downloaded model ready to transcribe.
+    ///
+    /// Loading a model takes tens of seconds the first time. Doing it lazily at
+    /// the first dictation means the user hits that wait mid-sentence, behind a
+    /// "warming up" label; doing it here spends the wait while they are still
+    /// looking at the AI Models screen, right after a download they already
+    /// waited on.
+    ///
+    /// Only warms the model the user is actually going to use: the selected one,
+    /// or any model when nothing is selected yet (the first-run case, where the
+    /// download that just finished is the one they came for).
+    private func warmUpAfterDownload(variant: String) {
+        let selected = UserDefaults.standard.string(forKey: ModelSelection.defaultsKey)
+            ?? ModelSelection.none
+        guard selected == variant || selected == ModelSelection.none else { return }
+        Task { @MainActor in
+            TranscriptionManager.shared.warmUp(variant: variant)
+        }
+    }
+
     /// Merges a fresh disk scan with the downloads that are still running.
     ///
     /// The AI Models screen refreshes on every appearance, so a refresh must not
@@ -348,6 +373,7 @@ class ModelDownloadService: ObservableObject {
                     self.isDownloading[variant] = false
                     self.downloadProgress[variant] = 1.0
                     self.activeTasks[variant] = nil // Cleanup task
+                    self.warmUpAfterDownload(variant: variant)
                 }
             } catch {
                 if Task.isCancelled {
@@ -393,6 +419,7 @@ class ModelDownloadService: ObservableObject {
                              self.downloadProgress[variant] = 1.0
                              self.downloadError[variant] = nil
                              self.activeTasks[variant] = nil
+                             self.warmUpAfterDownload(variant: variant)
                          }
                      } catch {
                          if Task.isCancelled { return }
@@ -445,6 +472,7 @@ class ModelDownloadService: ObservableObject {
                     self.isDownloading[variant] = false
                     self.downloadProgress[variant] = 1.0
                     self.activeTasks[variant] = nil
+                    self.warmUpAfterDownload(variant: variant)
                 }
             } catch {
                 if Task.isCancelled {

--- a/speaktype/Services/Transcription/TranscriptionManager.swift
+++ b/speaktype/Services/Transcription/TranscriptionManager.swift
@@ -82,10 +82,64 @@ class TranscriptionManager {
     }
 
     /// Load a specific model variant, routing to its owning engine.
+    ///
+    /// `activeKind` switches *before* the load, not after: the display-state
+    /// accessors above read whichever engine `activeKind` names, so setting it
+    /// afterwards meant `isLoading` / `loadingStage` reported the idle Whisper
+    /// engine for the whole time a Parakeet model was warming up. The recorder
+    /// never saw a load in progress and fell back to its truncated status text.
     func loadModel(variant: String) async throws {
         let kind = AIModel.engineKind(for: variant)
-        try await engine(for: kind).loadModel(variant: variant)
         activeKind = kind
+        try await engine(for: kind).loadModel(variant: variant)
+    }
+
+    // MARK: - Warm-up
+
+    /// Variant whose warm-up is currently in flight, if any. Readable so UI can
+    /// show readiness for the specific model it is displaying.
+    private(set) var warmingVariant: String?
+
+    /// True while a *background* warm-up is loading a model. Distinct from
+    /// `isLoading`, which is true for any load including one the user is
+    /// actively waiting on: UI that belongs to a dictation must not react to a
+    /// preload the user never asked for.
+    private(set) var isWarmingUp = false
+
+    /// Loads `variant` in the background so the first dictation doesn't pay the
+    /// model-load cost — the "warming up" wait users hit mid-sentence.
+    ///
+    /// Fire-and-forget and deduped: warming a model that is already loaded, or
+    /// re-warming one already in flight, is a no-op. Only downloaded models are
+    /// warmed, because `loadModel` otherwise falls through to FluidAudio's
+    /// download path and would silently pull gigabytes with no progress UI.
+    ///
+    /// - Returns: whether a warm-up was actually started.
+    @discardableResult
+    func warmUp(variant: String) -> Bool {
+        guard !variant.isEmpty else { return false }
+        guard warmingVariant != variant else { return false }
+        guard !(isInitialized && currentModelVariant == variant) else { return false }
+        guard ModelDownloadService.shared.isDownloaded(variant) else { return false }
+
+        warmingVariant = variant
+        isWarmingUp = true
+
+        Task { @MainActor in
+            do {
+                try await self.loadModel(variant: variant)
+                print("✅ Warmed up \(variant)")
+            } catch {
+                // A warm-up is best-effort: the model still loads on demand at
+                // the next dictation, which is where errors get surfaced.
+                print("⚠️ Warm-up failed for \(variant): \(error.localizedDescription)")
+            }
+            if self.warmingVariant == variant {
+                self.warmingVariant = nil
+                self.isWarmingUp = false
+            }
+        }
+        return true
     }
 
     /// Transcribe an audio file with the currently active engine.

--- a/speaktype/Views/Overlays/MiniRecorderView.swift
+++ b/speaktype/Views/Overlays/MiniRecorderView.swift
@@ -11,6 +11,11 @@ struct MiniRecorderView: View {
     @State private var isProcessing = false
     @State private var statusMessage = "Transcribing..."
     @State private var isWarmingUp = false
+    /// When the current warm-up began, so the pill can show elapsed seconds
+    /// instead of an open-ended spinner.
+    @State private var warmUpStart: Date?
+    @State private var warmUpElapsed: TimeInterval = 0
+    @State private var warmUpTimer: Timer?
     @State private var showAccessibilityWarning = false
     var onCommit: ((String) -> Void)?
     var onCancel: (() -> Void)?
@@ -264,7 +269,11 @@ struct MiniRecorderView: View {
     private enum RecorderPhase { case idle, warming, processing, recording }
 
     private var displayPhase: RecorderPhase {
-        if isWarmingUp || transcription.isLoading { return .warming }
+        // Deliberately *not* `transcription.isLoading`: that is also true for a
+        // background warm-up (after a download, or at launch), and the HUD must
+        // never expand for work the user didn't ask for. `isWarmingUp` is set
+        // only by this recorder's own load paths.
+        if isWarmingUp { return .warming }
         if isProcessing { return .processing }
         if isListening { return .recording }
         return .idle
@@ -275,7 +284,7 @@ struct MiniRecorderView: View {
     private var pillWidth: CGFloat {
         switch displayPhase {
         case .idle: return 58
-        case .warming: return 200
+        case .warming: return 320
         case .processing: return 210
         case .recording: return expanded ? 460 : 250
         }
@@ -309,15 +318,50 @@ struct MiniRecorderView: View {
         .transition(.opacity.combined(with: .scale(scale: 0.6)))
     }
 
+    /// What the pill says while a model loads.
+    ///
+    /// The engine publishes a real stage ("Loading Parakeet model…"); fall back
+    /// to a generic line only before the first stage arrives. Kept short on
+    /// purpose — this sits in a fixed-width capsule, and the previous copy
+    /// ("Warming up model — first use is slower…") was simply clipped mid-word.
+    private var warmUpLabel: String {
+        let stage = transcription.loadingStage
+        return stage.isEmpty ? "Getting model ready…" : stage
+    }
+
     private var warmingContent: some View {
         HStack(spacing: 8) {
             ProgressView()
                 .controlSize(.small)
                 .colorScheme(.dark)
-            Text("Warming up model...")
+
+            VStack(alignment: .leading, spacing: 1) {
+                Text(warmUpLabel)
+                    .font(Typography.pillLabel)
+                    .foregroundColor(.white.opacity(0.9))
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+
+                // A silent spinner gives no sense of how long this will take, so
+                // once it stops feeling instant, say how long it has been and
+                // that it only happens once.
+                if warmUpElapsed >= 3 {
+                    Text(warmUpElapsed >= 25
+                         ? "\(Int(warmUpElapsed))s · almost there, first load only"
+                         : "\(Int(warmUpElapsed))s · first load only")
+                        .font(Typography.pillLabel)
+                        .foregroundColor(.white.opacity(0.55))
+                        .lineLimit(1)
+                }
+            }
+
+            Spacer(minLength: 0)
+
+            Text("esc")
                 .font(Typography.pillLabel)
-                .foregroundColor(.white.opacity(0.9))
+                .foregroundColor(.white.opacity(0.4))
         }
+        .padding(.horizontal, 4)
         .transition(.opacity)
     }
 
@@ -626,14 +670,14 @@ struct MiniRecorderView: View {
                 // Pre-load the new model immediately so the first transcription isn't slow
                 if model.variant != previousModel {
                     Task {
-                        await MainActor.run { isWarmingUp = true }
+                        await MainActor.run { beginWarmUp() }
                         do {
                             try await transcription.loadModel(variant: model.variant)
                             debugLog("Model pre-loaded after switch: \(model.variant)")
                         } catch {
                             debugLog("Model pre-load failed: \(error.localizedDescription)")
                         }
-                        await MainActor.run { isWarmingUp = false }
+                        await MainActor.run { endWarmUp() }
                     }
                 }
             } label: {
@@ -834,8 +878,28 @@ struct MiniRecorderView: View {
         }
     }
 
+    /// Enter the warming phase and start counting seconds.
+    private func beginWarmUp() {
+        isWarmingUp = true
+        warmUpStart = Date()
+        warmUpElapsed = 0
+        warmUpTimer?.invalidate()
+        warmUpTimer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { _ in
+            if let start = warmUpStart { warmUpElapsed = Date().timeIntervalSince(start) }
+        }
+    }
+
+    /// Leave the warming phase. Safe to call when not warming.
+    private func endWarmUp() {
+        warmUpTimer?.invalidate()
+        warmUpTimer = nil
+        warmUpStart = nil
+        warmUpElapsed = 0
+        isWarmingUp = false
+    }
+
     private func handleEscape() {
-        guard isListening || isProcessing || isWarmingUp || transcription.isLoading else { return }
+        guard isListening || isProcessing || isWarmingUp else { return }
 
         debugLog("Escape pressed - cancelling immediate commit")
         cancelCommit = true
@@ -860,10 +924,17 @@ struct MiniRecorderView: View {
                 }
             }
         } else {
-            // Already processing, just show stopping and quickly dismiss
-            statusMessage = "Stopping transcription..."
+            // Already warming up or processing. Clearing both flags is what
+            // actually returns the pill to idle: `onCancel` only tells the
+            // window to settle, so leaving `isProcessing` set left the HUD
+            // wedged open — the status text stayed on screen with no way to
+            // dismiss it. The load itself keeps running in the background and
+            // will simply be ready for the next dictation.
+            statusMessage = isWarmingUp ? "Continuing in background..." : "Stopping transcription..."
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.8) {
-                onCancel?()
+                self.endWarmUp()
+                self.isProcessing = false
+                self.onCancel?()
             }
         }
     }
@@ -891,13 +962,18 @@ struct MiniRecorderView: View {
             if !transcription.isInitialized || transcription.currentModelVariant != selectedModel
             {
                 debugLog("Loading model: \(selectedModel)")
-                await MainActor.run { statusMessage = "Warming up model — first use is slower..." }
+                // Show the dedicated warming phase (spinner + live stage +
+                // elapsed) rather than a long sentence stuffed into the
+                // fixed-width processing pill, where it was clipped mid-word.
+                await MainActor.run { beginWarmUp() }
                 do {
                     try await transcription.loadModel(variant: selectedModel)
                     debugLog("Model loaded successfully")
+                    await MainActor.run { endWarmUp() }
                 } catch {
                     debugLog("Model load failed: \(error.localizedDescription)")
                     await MainActor.run {
+                        endWarmUp()
                         statusMessage = "Model load failed"
                         DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) {
                             self.isProcessing = false

--- a/speaktype/Views/Screens/Dashboard/DashboardView.swift
+++ b/speaktype/Views/Screens/Dashboard/DashboardView.swift
@@ -175,22 +175,13 @@ struct DashboardView: View {
                 print("File selection error: \(error.localizedDescription)")
             }
         }
-        .onAppear {
-            Task {
-                guard !selectedModel.isEmpty else { return }
-                if !transcription.isInitialized
-                    || transcription.currentModelVariant != selectedModel
-                {
-                    try? await transcription.loadModel(variant: selectedModel)
-                }
-            }
-        }
-        .onChange(of: selectedModel) {
-            Task {
-                guard !selectedModel.isEmpty else { return }
-                try? await transcription.loadModel(variant: selectedModel)
-            }
-        }
+        // Route both preloads through `warmUp`, which dedupes: two screens (or a
+        // post-download warm-up) asking for the same model used to start two
+        // concurrent loads of the same weights. It also refuses to load a model
+        // that isn't downloaded, instead of silently falling through to the
+        // engine's download path.
+        .onAppear { transcription.warmUp(variant: selectedModel) }
+        .onChange(of: selectedModel) { transcription.warmUp(variant: selectedModel) }
     }
 
     // MARK: - Helpers

--- a/speaktype/Views/Screens/Settings/AIModelsView.swift
+++ b/speaktype/Views/Screens/Settings/AIModelsView.swift
@@ -12,6 +12,7 @@ struct AIModelsView: View {
 
     // MARK: - Derived
 
+    private var transcription: TranscriptionManager { TranscriptionManager.shared }
     private var capability: DeviceCapability { .current }
     private var useCase: AIModel.UseCase { AIModel.UseCase(rawValue: useCaseRaw) ?? .dictation }
     private var recommendedModel: AIModel { AIModel.recommendedModel(for: capability, useCase: useCase) }
@@ -20,7 +21,7 @@ struct AIModelsView: View {
     }
 
     private func isDownloaded(_ variant: String) -> Bool {
-        (downloadService.downloadProgress[variant] ?? 0) >= 1.0
+        downloadService.isDownloaded(variant)
     }
 
     /// Engine groups for the list — the recommended model is intentionally left
@@ -196,10 +197,21 @@ struct AIModelsView: View {
     private func heroAction(rec: AIModel, downloaded: Bool, active: Bool) -> some View {
         let downloading = downloadService.isDownloading[rec.variant] ?? false
         let error = downloadService.downloadError[rec.variant]
+        let warming = transcription.warmingVariant == rec.variant
 
         return VStack(alignment: .leading, spacing: 12) {
             if downloading {
                 heroDownloadProgress(variant: rec.variant)
+            } else if warming {
+                // Checked before the "default model" branch: selecting flips
+                // `active` immediately, so an equally-early `active` check would
+                // hide the readiness spinner entirely.
+                HStack(spacing: 9) {
+                    Spinner(size: 13, lineWidth: 2, tint: Color.brandAccent)
+                    Text("Getting it ready…")
+                        .font(Typography.uiBold(13))
+                        .foregroundStyle(Color.textSecondary)
+                }
             } else if active && downloaded {
                 HStack(spacing: 7) {
                     Image(systemName: "checkmark.circle.fill")
@@ -208,7 +220,12 @@ struct AIModelsView: View {
                 .foregroundStyle(Color.brandAccent)
             } else if downloaded {
                 Button {
+                    // Selecting used to only write the preference, leaving the
+                    // model to load lazily at the first dictation — which is
+                    // exactly the mid-sentence "warming up" wait. Load it here,
+                    // while the user is still on this screen.
                     selectedModel = rec.variant
+                    transcription.warmUp(variant: rec.variant)
                 } label: {
                     ActionButton.label(title: "Use this model", icon: "arrow.right",
                                        style: .primary, large: true)

--- a/speaktypeTests/TranscriptionWarmUpTests.swift
+++ b/speaktypeTests/TranscriptionWarmUpTests.swift
@@ -1,0 +1,57 @@
+import XCTest
+@testable import speaktype
+
+/// Guards the rules that decide whether a model gets warmed up in the
+/// background, so the first dictation doesn't pay the model-load cost.
+@MainActor
+final class TranscriptionWarmUpTests: XCTestCase {
+
+    private var manager: TranscriptionManager { TranscriptionManager.shared }
+    private var downloads: ModelDownloadService { ModelDownloadService.shared }
+
+    private let variant = ParakeetCatalog.v2Variant
+    private var savedProgress: [String: Double] = [:]
+
+    override func setUp() {
+        super.setUp()
+        savedProgress = downloads.downloadProgress
+    }
+
+    override func tearDown() {
+        downloads.downloadProgress = savedProgress
+        super.tearDown()
+    }
+
+    func testWarmUpIsSkippedForAnEmptyVariant() {
+        XCTAssertFalse(manager.warmUp(variant: ""))
+        XCTAssertNil(manager.warmingVariant)
+    }
+
+    func testWarmUpIsSkippedWhenTheModelIsNotDownloaded() {
+        // Loading an absent model falls through to the engine's own download
+        // path, which would pull gigabytes with no progress UI. Warm-up must
+        // never trigger that.
+        downloads.downloadProgress[variant] = 0.0
+
+        XCTAssertFalse(manager.warmUp(variant: variant))
+        XCTAssertNil(manager.warmingVariant)
+    }
+
+    func testWarmUpIsSkippedForAPartiallyDownloadedModel() {
+        downloads.downloadProgress[variant] = 0.87
+
+        XCTAssertFalse(manager.warmUp(variant: variant))
+        XCTAssertNil(manager.warmingVariant)
+    }
+
+    func testIsDownloadedTracksCompletionOnly() {
+        downloads.downloadProgress[variant] = 0.99
+        XCTAssertFalse(downloads.isDownloaded(variant))
+
+        downloads.downloadProgress[variant] = 1.0
+        XCTAssertTrue(downloads.isDownloaded(variant))
+
+        downloads.downloadProgress.removeValue(forKey: variant)
+        XCTAssertFalse(downloads.isDownloaded(variant))
+    }
+}


### PR DESCRIPTION
Reported from a first-run session: the recorder pill showed **"Warming up model — first use is..."** — clipped mid-word, stuck on screen with no way to dismiss it, no indication of how long it would take, and it appeared at the worst possible moment (mid-sentence, on the first dictation).

Four separate defects behind that one screenshot.

### 1. Nothing warmed the model up ahead of time

The hero's "Use this model" only wrote the AppStorage key — no load at all. `DashboardView`'s preload only runs while that screen is on-screen, and after a download the user is on **AI Models**, not the dashboard. So the model loaded lazily *inside* the first dictation.

Models now warm up when a download finishes and when one is selected, through a new deduped `TranscriptionManager.warmUp(variant:)`. It refuses to load a model that isn't fully downloaded — `loadModel` otherwise falls through to FluidAudio's `downloadAndLoad`, which would silently pull ~2 GB behind a "warming up" label with no progress UI. `DashboardView`'s two preloads now route through it as well, so two screens asking for the same model no longer start two concurrent loads of the same weights.

### 2. The text was clipped because the pill was in the wrong phase

`TranscriptionManager.loadModel` set `activeKind` **after** the load. The display-state accessors read whichever engine `activeKind` names, so `isLoading` / `loadingStage` reported the idle *Whisper* engine for the entire time a *Parakeet* model was warming. `displayPhase` never became `.warming`, so the pill rendered the `.processing` branch — a `lineLimit(1)` `Text(statusMessage)` in a fixed 210pt capsule, holding the long sentence "Warming up model — first use is slower...". Hence the truncation in the screenshot. `activeKind` now switches before the load.

### 3. Escape left the HUD wedged open

The processing branch of `handleEscape` called `onCancel` — which per `MiniRecorderWindowController` only tells the window to *settle back to idle*, it does not hide anything — without ever clearing `isProcessing`. `displayPhase` stayed `.processing`, so the status text sat on screen with no way to dismiss it. Escape now clears both flags; the load continues in the background and is simply ready for the next dictation.

### 4. No sense of how long

The warming pill now shows the engine's live loading stage, elapsed seconds once it stops feeling instant (3s), that it only happens on first load, and an `esc` affordance. Widened 200 → 320pt so real text fits.

One deliberate call: `displayPhase` no longer keys off `transcription.isLoading`. That is also true during a *background* warm-up, and with fix #2 in place it would have expanded the HUD unprompted after every download and every launch. The pill now only reflects warm-ups it started itself.

## Testing

New `TranscriptionWarmUpTests` covering the warm-up guard rules (empty variant, not downloaded, partially downloaded) and the shared `isDownloaded` readiness check. The positive path deliberately isn't unit-tested — it would load real multi-GB CoreML weights.

Note: authored on a machine without Xcode, so **CI is the build/test gate here**; all files pass `swiftc -parse`.