### PR TITLE
feat: list audio input devices in the menu bar for quick device switching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on Keep a Changelog, and this project adheres to Semantic Versioning.
 
 ## [Unreleased]
+- New: Settings → Audio now has a "Show audio devices in menu bar" option. When enabled, the SpeakType menu bar item lists your input microphones so you can switch devices (e.g. after plugging in a dock) without opening Settings.
 - Models are now warmed up as soon as they finish downloading (and when you pick one), so the first dictation no longer stalls on "warming up".
 - Fix: the recorder's warming-up message was clipped mid-word, and pressing esc left it wedged on screen. It now shows the real loading stage, elapsed time, and settles back to idle.
 - Fix: the recommended model on the AI Models screen now shows download progress, a cancel button, and the actual reason a download failed (with a retry) instead of a Download button that appeared to do nothing.

--- a/speaktype/Views/Components/MenuBarDashboardView.swift
+++ b/speaktype/Views/Components/MenuBarDashboardView.swift
@@ -1,8 +1,11 @@
+import AVFoundation
 import AppKit
 import SwiftUI
 
 struct MenuBarDashboardView: View {
     @StateObject private var historyService = HistoryService.shared
+    @StateObject private var audioRecorder = AudioRecordingService.shared
+    @AppStorage("showAudioDevicesInMenuBar") private var showAudioDevicesInMenuBar: Bool = false
 
     let openDashboard: () -> Void
     let quit: () -> Void
@@ -36,11 +39,62 @@ struct MenuBarDashboardView: View {
         VStack(alignment: .leading, spacing: 16) {
             header
             statsGrid
+            if showAudioDevicesInMenuBar {
+                audioDevicesSection
+            }
             recentTranscriptsSection
             actionRow
         }
         .padding(16)
         .frame(width: 388)
+        .onAppear { audioRecorder.fetchAvailableDevices() }
+    }
+
+    private var audioDevicesSection: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack {
+                Label("Input Device", systemImage: "mic")
+                    .font(Typography.headlineMedium)
+                    .foregroundStyle(Color.textPrimary)
+
+                Spacer()
+
+                Button(action: { audioRecorder.fetchAvailableDevices() }) {
+                    HStack(spacing: 4) {
+                        Image(systemName: "arrow.clockwise")
+                            .font(.system(size: 11))
+                        Text("Refresh")
+                            .font(Typography.captionSmall)
+                    }
+                    .foregroundStyle(Color.textSecondary)
+                }
+                .buttonStyle(.plain)
+            }
+
+            if audioRecorder.availableDevices.isEmpty {
+                Text("No input devices found")
+                    .font(Typography.caption)
+                    .foregroundStyle(Color.textSecondary)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(14)
+                    .background(Color.bgCard)
+                    .clipShape(RoundedRectangle(cornerRadius: 12))
+                    .overlay {
+                        RoundedRectangle(cornerRadius: 12)
+                            .stroke(Color.border, lineWidth: 1)
+                    }
+            } else {
+                VStack(spacing: 8) {
+                    ForEach(audioRecorder.availableDevices, id: \.uniqueID) { device in
+                        MenuBarDeviceRow(
+                            name: device.localizedName,
+                            isSelected: audioRecorder.selectedDeviceId == device.uniqueID,
+                            action: { audioRecorder.selectedDeviceId = device.uniqueID }
+                        )
+                    }
+                }
+            }
+        }
     }
 
     private var header: some View {
@@ -251,6 +305,46 @@ private struct MenuBarStatCard: View {
             RoundedRectangle(cornerRadius: 12)
                 .stroke(Color.border, lineWidth: 1)
         }
+    }
+}
+
+private struct MenuBarDeviceRow: View {
+    let name: String
+    let isSelected: Bool
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            HStack(spacing: 10) {
+                Image(systemName: "mic")
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundStyle(isSelected ? Color.accentPrimary : Color.textSecondary)
+                    .frame(width: 24, height: 24)
+                    .background((isSelected ? Color.accentPrimary : Color.textSecondary).opacity(0.12))
+                    .clipShape(RoundedRectangle(cornerRadius: 7))
+
+                Text(name)
+                    .font(Typography.bodySmall)
+                    .foregroundStyle(Color.textPrimary)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+
+                if isSelected {
+                    Image(systemName: "checkmark")
+                        .font(.system(size: 11, weight: .semibold))
+                        .foregroundStyle(Color.accentPrimary)
+                }
+            }
+            .padding(10)
+            .background(Color.bgCard)
+            .clipShape(RoundedRectangle(cornerRadius: 12))
+            .overlay {
+                RoundedRectangle(cornerRadius: 12)
+                    .stroke(isSelected ? Color.accentPrimary : Color.border, lineWidth: 1)
+            }
+        }
+        .buttonStyle(.plain)
     }
 }
 

--- a/speaktype/Views/Screens/Settings/SettingsView.swift
+++ b/speaktype/Views/Screens/Settings/SettingsView.swift
@@ -560,6 +560,7 @@ struct GeneralSettingsTab: View {
 
 struct AudioSettingsTab: View {
     @StateObject private var audioRecorder = AudioRecordingService.shared
+    @AppStorage("showAudioDevicesInMenuBar") private var showAudioDevicesInMenuBar: Bool = false
 
     var body: some View {
         ScrollView {
@@ -603,6 +604,27 @@ struct AudioSettingsTab: View {
                     }
                     .buttonStyle(.plain)
                     .padding(.top, 8)
+                }
+
+                SettingsSection {
+                    SettingsSectionHeader(
+                        icon: "menucard", title: "Menu Bar",
+                        subtitle: "What the SpeakType menu bar item shows")
+
+                    HStack {
+                        Text("Show audio devices in menu bar")
+                            .font(Typography.bodyMedium)
+                            .foregroundStyle(Color.textPrimary)
+                        Spacer()
+                        Toggle("", isOn: $showAudioDevicesInMenuBar)
+                            .labelsHidden()
+                    }
+
+                    Text(
+                        "Lists your input microphones on the SpeakType menu bar item so you can switch devices without opening Settings."
+                    )
+                    .font(Typography.captionSmall)
+                    .foregroundStyle(Color.textMuted)
                 }
             }
             .padding(24)


### PR DESCRIPTION
## What this changes

Switching the input microphone today requires opening Settings → Audio every time, which is annoying when devices change often (e.g. plugging a laptop into a dock, where the internal mic stops being usable).

This adds a **"Show audio devices in menu bar"** toggle to Settings → Audio. When enabled, the SpeakType menu bar popover lists all available input microphones, and tapping a device selects it immediately — no need to open Settings.

## Details

- **Settings → Audio** — new standalone "Menu Bar" settings card (below the Input Device card) with the toggle. Persisted via `showAudioDevicesInMenuBar`, off by default.
- **Menu bar popover** (`MenuBarDashboardView`) — new "Input Device" section between the stats grid and the recent transcripts:
  - tappable row per input microphone, with a checkmark and accent border on the active device
  - Refresh button; the list re-fetches every time the popover opens
  - live updates on plug/unplug — `AudioRecordingService` already observes `AVCaptureDevice.wasConnected`/`wasDisconnected`
  - selection persists (same `selectedDeviceId` UserDefaults path as the settings screen)

## Verification

- `make build` succeeds
- all 73 unit tests pass
- manual: toggling the setting changes the popover height from 492pt → 619pt (section header + 2 device rows on a two-mic machine), and tapping a row switches the active mic instantly

Happy to adjust the wording, the default state, or the section placement if there's a better fit for the project.
